### PR TITLE
USSD public - handle session time-outs

### DIFF
--- a/go-app-sms.js
+++ b/go-app-sms.js
@@ -22,6 +22,10 @@ go.utils = {
             && im.config.no_timeout_redirects.indexOf(im.user.state.name) === -1;
     },
 
+    timeout_redirect: function(im) {
+        return im.config.timeout_redirects.indexOf(im.user.state.name) !== -1;
+    },
+
 
 // SERVICE API CALL HELPERS
 

--- a/go-app-ussd_health_worker.js
+++ b/go-app-ussd_health_worker.js
@@ -22,6 +22,10 @@ go.utils = {
             && im.config.no_timeout_redirects.indexOf(im.user.state.name) === -1;
     },
 
+    timeout_redirect: function(im) {
+        return im.config.timeout_redirects.indexOf(im.user.state.name) !== -1;
+    },
+
 
 // SERVICE API CALL HELPERS
 

--- a/go-app-ussd_public.js
+++ b/go-app-ussd_public.js
@@ -628,7 +628,7 @@ go.app = function() {
                         // Prevent previous content being passed to next state
                         self.im.msg.session_event = null;
 
-                        return self.states.create('state_start', pass_opts);
+                        return self.states.create('state_permission', pass_opts);
                     }
 
                 }

--- a/go-app-ussd_public.js
+++ b/go-app-ussd_public.js
@@ -640,6 +640,8 @@ go.app = function() {
                     } else {
                         // Prevent previous content being passed to next state
                         self.im.msg.session_event = null;
+                        // reset user answers
+                        self.im.user.answers = {};
 
                         return self.states.create('state_permission', pass_opts);
                     }
@@ -666,7 +668,7 @@ go.app = function() {
                         };
                         // return creator_opts.name;
                     } else if (choice.value === 'restart') {
-                        // Reset user answers when restarting the app
+                        // reset user answers
                         self.im.user.answers = {};
                         return 'state_start';
                     }

--- a/go-app-ussd_public.js
+++ b/go-app-ussd_public.js
@@ -508,7 +508,6 @@ go.app = function() {
     var GoFC = App.extend(function(self) {
         App.call(self, 'state_start');
         var $ = self.$;
-        var interrupt = true;
 
         self.init = function() {
 
@@ -612,10 +611,9 @@ go.app = function() {
         // override normal state adding
         self.add = function(name, creator) {
             self.states.add(name, function(name, opts) {
-                if (!interrupt || !go.utils.timed_out(self.im))
+                if (!go.utils.timed_out(self.im))
                     return creator(name, opts);
 
-                interrupt = false;
                 opts = opts || {};
                 opts.name = name;
                 return self.states.create('state_timed_out', opts);

--- a/go-app-ussd_public.js
+++ b/go-app-ussd_public.js
@@ -776,7 +776,7 @@ go.app = function() {
                         return self.states.create('state_change_menu');
                     } else {
                         self.im.user.set_answer('contact_id', contact.id);
-                        return self.states.create('state_registration_menu');
+                        return self.states.create('state_msg_receiver');  // for phase 1, state_registration_menu will be skipped
                     }
                 });
         });

--- a/src/ussd_public.js
+++ b/src/ussd_public.js
@@ -11,7 +11,6 @@ go.app = function() {
     var GoFC = App.extend(function(self) {
         App.call(self, 'state_start');
         var $ = self.$;
-        var interrupt = true;
 
         self.init = function() {
 
@@ -115,10 +114,9 @@ go.app = function() {
         // override normal state adding
         self.add = function(name, creator) {
             self.states.add(name, function(name, opts) {
-                if (!interrupt || !go.utils.timed_out(self.im))
+                if (!go.utils.timed_out(self.im))
                     return creator(name, opts);
 
-                interrupt = false;
                 opts = opts || {};
                 opts.name = name;
                 return self.states.create('state_timed_out', opts);

--- a/src/ussd_public.js
+++ b/src/ussd_public.js
@@ -127,7 +127,7 @@ go.app = function() {
                         // Prevent previous content being passed to next state
                         self.im.msg.session_event = null;
 
-                        return self.states.create('state_start', pass_opts);
+                        return self.states.create('state_permission', pass_opts);
                     }
 
                 }

--- a/src/ussd_public.js
+++ b/src/ussd_public.js
@@ -262,7 +262,7 @@ go.app = function() {
                         return self.states.create('state_change_menu');
                     } else {
                         self.im.user.set_answer('contact_id', contact.id);
-                        return self.states.create('state_registration_menu');
+                        return self.states.create('state_msg_receiver');  // for phase 1, state_registration_menu will be skipped
                     }
                 });
         });

--- a/src/ussd_public.js
+++ b/src/ussd_public.js
@@ -56,6 +56,8 @@ go.app = function() {
                 "Please enter the number you would like to manage. For example 0803304899.  Note: You should permission from the owner to manage this number.",
             "state_change_menu":
                 "Choose:",
+            "state_registration_menu":
+                "Choose from:",
 
             "state_already_baby":
                 "You are already registered for baby messages.",
@@ -114,12 +116,23 @@ go.app = function() {
         // override normal state adding
         self.add = function(name, creator) {
             self.states.add(name, function(name, opts) {
-                if (!go.utils.timed_out(self.im))
-                    return creator(name, opts);
+                var pass_opts = opts || {};
+                pass_opts.name = name;
 
-                opts = opts || {};
-                opts.name = name;
-                return self.states.create('state_timed_out', opts);
+                if (go.utils.timed_out(self.im))
+                {
+                    if (go.utils.timeout_redirect(self.im)) {
+                        return self.states.create('state_timed_out', pass_opts);
+                    } else {
+                        // Prevent previous content being passed to next state
+                        self.im.msg.session_event = null;
+
+                        return self.states.create('state_start', pass_opts);
+                    }
+
+                }
+
+                return creator(name, pass_opts);
             });
         };
 
@@ -139,6 +152,8 @@ go.app = function() {
                         };
                         // return creator_opts.name;
                     } else if (choice.value === 'restart') {
+                        // Reset user answers when restarting the app
+                        self.im.user.answers = {};
                         return 'state_start';
                     }
                 }
@@ -183,7 +198,7 @@ go.app = function() {
         // ChoiceState st-C
         self.add('state_permission', function(name) {
             return new ChoiceState(name, {
-                question: $(questions[name]).context({msisdn: self.im.user.addr}),
+                question: $(questions[name]).context({'msisdn': self.im.user.addr}),
                 choices: [
                     new Choice('has_permission', $('Yes')),
                     new Choice('no_permission', $('No')),
@@ -245,7 +260,7 @@ go.app = function() {
                         return self.states.create('state_change_menu');
                     } else {
                         self.im.user.set_answer('contact_id', contact.id);
-                        return self.states.create('state_msg_receiver');
+                        return self.states.create('state_registration_menu');
                     }
                 });
         });
@@ -260,6 +275,20 @@ go.app = function() {
                     new Choice('state_change_language', $('Update language')),
                     new Choice('state_change_number', $("Change the number which gets SMSs")),
                     new Choice('state_optout_reason', $("Stop SMSs")),
+                ],
+                next: function(choice) {
+                    return choice.value;
+                }
+            });
+        });
+
+        // ChoiceState st-A2
+        self.add('state_registration_menu', function(name) {
+            return new ChoiceState(name, {
+                question: $(questions[name]),
+                error: $(get_error_text(name)),
+                choices: [
+                    new Choice('state_msg_receiver', $('Register to receive SMSs about you & your baby'))
                 ],
                 next: function(choice) {
                     return choice.value;

--- a/src/ussd_public.js
+++ b/src/ussd_public.js
@@ -126,6 +126,8 @@ go.app = function() {
                     } else {
                         // Prevent previous content being passed to next state
                         self.im.msg.session_event = null;
+                        // reset user answers
+                        self.im.user.answers = {};
 
                         return self.states.create('state_permission', pass_opts);
                     }
@@ -152,7 +154,7 @@ go.app = function() {
                         };
                         // return creator_opts.name;
                     } else if (choice.value === 'restart') {
-                        // Reset user answers when restarting the app
+                        // reset user answers
                         self.im.user.answers = {};
                         return 'state_start';
                     }

--- a/src/utils.js
+++ b/src/utils.js
@@ -15,6 +15,10 @@ go.utils = {
             && im.config.no_timeout_redirects.indexOf(im.user.state.name) === -1;
     },
 
+    timeout_redirect: function(im) {
+        return im.config.timeout_redirects.indexOf(im.user.state.name) !== -1;
+    },
+
 
 // SERVICE API CALL HELPERS
 

--- a/test/ussd_public.test.js
+++ b/test/ussd_public.test.js
@@ -57,7 +57,7 @@ describe("familyconnect health worker app", function() {
 
         // TEST TIMEOUTS
 
-        describe.only("Timeout testing", function() {
+        describe("Timeout testing", function() {
             describe("in State Change", function() {
                 it("should restart at state C (state_permission)", function() {
                     return tester
@@ -134,7 +134,6 @@ describe("familyconnect health worker app", function() {
                         .inputs(
                             {session_event: 'new'}  // dial in
                             , '1'  // state_permission
-                            , '1'  // state_registeration_menu - register
                             , '1'  // state_msg_receiver - head of household
                             , {session_event: 'close'}
                             , {session_event: 'new'}
@@ -155,7 +154,6 @@ describe("familyconnect health worker app", function() {
                         .inputs(
                             {session_event: 'new'}  // dial in
                             , '1'  // state_permission
-                            , '1'  // state_registeration_menu - register
                             , '1'  // state_msg_receiver - head of household
                             , {session_event: 'close'}
                             , {session_event: 'new'}
@@ -179,7 +177,6 @@ describe("familyconnect health worker app", function() {
                         .inputs(
                             {session_event: 'new'}  // dial in
                             , '1'  // state_permission
-                            , '1'  // state_registeration_menu - register
                             , '1'  // state_msg_receiver - head of household
                             , '3'  // state_last_period_month
                             , {session_event: 'close'}

--- a/test/ussd_public.test.js
+++ b/test/ussd_public.test.js
@@ -59,7 +59,7 @@ describe("familyconnect health worker app", function() {
 
         describe.only("Timeout testing", function() {
             describe("in State Change", function() {
-                it("should ask about continuing", function() {
+                it("should restart at state C (state_permission)", function() {
                     return tester
                         .setup.user.addr('0720000222')
                         .inputs(
@@ -73,6 +73,52 @@ describe("familyconnect health worker app", function() {
                             state: 'state_permission',
                             reply: [
                                 "Welcome to FamilyConnect. Do you have permission to manage the number 0720000222?",
+                                "1. Yes",
+                                "2. No",
+                                "3. Change the number I'd like to manage"
+                            ].join('\n')
+                        })
+                        .run();
+                });
+                it("should restart at state C (state_permission) after two time-outs", function() {
+                    return tester
+                        .setup.user.addr('0720000222')
+                        .inputs(
+                            {session_event: 'new'}  // dial in
+                            , '1'  // state_permission - yes
+                            , '3'  // state_change_menu - change number
+                            , {session_event: 'close'}
+                            , {session_event: 'new'}
+                            , '1'  // state_permission - yes
+                            , '3'  // state_change_menu - change number
+                            , '0720000111'  // state_change_number
+                            , {session_event: 'close'}
+                            , {session_event: 'new'}
+                        )
+                        .check.interaction({
+                            state: 'state_permission',
+                            reply: [
+                                "Welcome to FamilyConnect. Do you have permission to manage the number 0720000222?",
+                                "1. Yes",
+                                "2. No",
+                                "3. Change the number I'd like to manage"
+                            ].join('\n')
+                        })
+                        .run();
+                });
+                it("should restart at state C (state_permission) as guest with unrecognised number", function() {
+                    return tester
+                        .setup.user.addr('0720000111')
+                        .inputs(
+                            {session_event: 'new'}  // dial in
+                            , '1'  // state_language - english
+                            , {session_event: 'close'}
+                            , {session_event: 'new'}
+                        )
+                        .check.interaction({
+                            state: 'state_permission',
+                            reply: [
+                                "Welcome to FamilyConnect. Do you have permission to manage the number 0720000111?",
                                 "1. Yes",
                                 "2. No",
                                 "3. Change the number I'd like to manage"

--- a/test/ussd_public.test.js
+++ b/test/ussd_public.test.js
@@ -45,55 +45,74 @@ describe("familyconnect health worker app", function() {
 
         // TEST TIMEOUTS
 
-        describe("Timeout testing", function() {
-            it("should ask about continuing", function() {
-                return tester
-                    .setup.user.addr('0720000111')
-                    .inputs(
-                        {session_event: 'new'}  // dial in
-                        , '1'  // state_language - english
-                        , {session_event: 'close'}
-                        , {session_event: 'new'}
-                    )
-                    .check.interaction({
-                        state: 'state_timed_out',
-                        reply: [
-                            "You have an incomplete registration. Would you like to continue with this registration?",
-                            "1. Yes",
-                            "2. No, start from the beginning"
-                        ].join('\n')
-                    })
-                    .run();
+        describe.skip("Timeout testing", function() {
+            describe("in State Change", function() {
+                it("should ask about continuing", function() {
+                    return tester
+                        .setup.user.addr('0720000111')
+                        .inputs(
+                            {session_event: 'new'}  // dial in
+                            , "3"  // state_permission - change number to manage
+                            , "0720000333"  // state_manage_msisdn - unregistered user
+                            , "4"  // state_msg_receiver - trusted friend
+                            , "3"  // state_last_period_month - may
+                            , "22"  // state_last_period_day
+                            , {session_event: 'close'}
+                            , {session_event: 'new'}
+                        )
+                        .check.interaction({
+                            state: 'state_permission',
+                            reply: "Welcome to FamilyConnect. Do you have permission to manage the number 0720000333?"
+                        })
+                        .run();
+                });
             });
-            it("should continue", function() {
-                return tester
-                    .setup.user.addr('0720000111')
-                    .inputs(
-                        {session_event: 'new'}  // dial in
-                        , '1'  // state_language - english
-                        , {session_event: 'close'}
-                        , {session_event: 'new'}
-                        , '1'  // state_timed_out - continue
-                    )
-                    .check.interaction({
-                        state: 'state_permission'
-                    })
-                    .run();
-            });
-            it("should restart", function() {
-                return tester
-                    .setup.user.addr('0720000111')
-                    .inputs(
-                        {session_event: 'new'}  // dial in
-                        , '1'  // state_language - english
-                        , {session_event: 'close'}
-                        , {session_event: 'new'}
-                        , '2'  // state_timed_out - restart
-                    )
-                    .check.interaction({
-                        state: 'state_language'
-                    })
-                    .run();
+            describe("in Registration", function() {
+                it("should continue", function() {
+                    return tester
+                        .setup.user.addr('0720000111')
+                        .inputs(
+                            {session_event: 'new'}  // dial in
+                            , '1'  // state_language - english
+                            , {session_event: 'close'}
+                            , {session_event: 'new'}
+                            , '1'  // state_timed_out - continue
+                        )
+                        .check.interaction({
+                            state: 'state_permission'
+                        })
+                        .run();
+                });
+                it("should restart", function() {
+                    return tester
+                        .setup.user.addr('0720000111')
+                        .inputs(
+                            {session_event: 'new'}  // dial in
+                            , '1'  // state_language - english
+                            , {session_event: 'close'}
+                            , {session_event: 'new'}
+                            , '2'  // state_timed_out - restart
+                        )
+                        .check.interaction({
+                            state: 'state_language'
+                        })
+                        .run();
+                });
+                it("should restart", function() {
+                    return tester
+                        .setup.user.addr('0720000111')
+                        .inputs(
+                            {session_event: 'new'}  // dial in
+                            , '1'  // state_language - english
+                            , {session_event: 'close'}
+                            , {session_event: 'new'}
+                            , '2'  // state_timed_out - restart
+                        )
+                        .check.interaction({
+                            state: 'state_language'
+                        })
+                        .run();
+                });
             });
         });
 


### PR DESCRIPTION
two different sets of behaviour required for session time-outs, one for the change-part of the app and one for the mini-registration part.

For the change-part, flow needs to be rerouted back to state/screen C (no asking for language preference again).
For the registration-part, a state/screen will ask the user whether they'd like to continue or restart.
