### PR TITLE
USSD public - add servicerating flow

### DIFF
--- a/go-app-sms.js
+++ b/go-app-sms.js
@@ -878,7 +878,7 @@ go.utils_project = {
         return go.utils
             .get_identity_by_address(address, im)
             .then(function(identity) {
-                return identity.servicerating_unanswered;
+                return identity.details.servicerating_unanswered;
             });
     },
 

--- a/go-app-sms.js
+++ b/go-app-sms.js
@@ -871,6 +871,17 @@ go.utils_project = {
         }
     },
 
+    // SERVICERATING HELPERS
+
+    // returns true if service rating unanswered
+    check_servicerating_status: function(address, im) {
+        return go.utils
+            .get_identity_by_address(address, im)
+            .then(function(identity) {
+                return identity.servicerating_unanswered;
+            });
+    },
+
     "commas": "commas"
 };
 

--- a/go-app-ussd_health_worker.js
+++ b/go-app-ussd_health_worker.js
@@ -878,7 +878,7 @@ go.utils_project = {
         return go.utils
             .get_identity_by_address(address, im)
             .then(function(identity) {
-                return identity.servicerating_unanswered;
+                return identity.details.servicerating_unanswered;
             });
     },
 

--- a/go-app-ussd_health_worker.js
+++ b/go-app-ussd_health_worker.js
@@ -871,6 +871,17 @@ go.utils_project = {
         }
     },
 
+    // SERVICERATING HELPERS
+
+    // returns true if service rating unanswered
+    check_servicerating_status: function(address, im) {
+        return go.utils
+            .get_identity_by_address(address, im)
+            .then(function(identity) {
+                return identity.servicerating_unanswered;
+            });
+    },
+
     "commas": "commas"
 };
 

--- a/go-app-ussd_public.js
+++ b/go-app-ussd_public.js
@@ -871,6 +871,17 @@ go.utils_project = {
         }
     },
 
+    // SERVICERATING HELPERS
+
+    // returns true if service rating unanswered
+    check_servicerating_status: function(address, im) {
+        return go.utils
+            .get_identity_by_address(address, im)
+            .then(function(identity) {
+                return identity.servicerating_unanswered;
+            });
+    },
+
     "commas": "commas"
 };
 

--- a/go-app-ussd_public.js
+++ b/go-app-ussd_public.js
@@ -1553,10 +1553,10 @@ go.app = function() {
         // ChoiceState
         self.add('state_servicerating_question1', function(name) {
             //var q_id = '1';
-            var q_text_en = "Welcome. When you signed up, were staff at the facility friendly & helpful?";
+            var q_text_en = $("Welcome. When you signed up, were staff at the facility friendly & helpful?");
 
             return new ChoiceState(name, {
-                question: $(q_text_en),
+                question: q_text_en,
                 choices: [
                     new Choice('very-satisfied', $('Very Satisfied')),
                     new Choice('satisfied', $('Satisfied')),
@@ -1570,10 +1570,10 @@ go.app = function() {
         // ChoiceState
         self.add('state_servicerating_question2', function(name) {
             //var q_id = '2';
-            var q_text_en = "How do you feel about the time you had to wait at the facility?";
+            var q_text_en = $("How do you feel about the time you had to wait at the facility?");
 
             return new ChoiceState(name, {
-                question: $(q_text_en),
+                question: q_text_en,
                 choices: [
                     new Choice('very-satisfied', $('Very Satisfied')),
                     new Choice('satisfied', $('Satisfied')),
@@ -1587,10 +1587,10 @@ go.app = function() {
         // ChoiceState
         self.add('state_servicerating_question3', function(name) {
             //var q_id = '3';
-            var q_text_en = "How long did you wait to be helped at the clinic?";
+            var q_text_en = $("How long did you wait to be helped at the clinic?");
 
             return new ChoiceState(name, {
-                question: $(q_text_en),
+                question: q_text_en,
                 choices: [
                     new Choice('less-than-an-hour', $('Less than an hour')),
                     new Choice('between-1-and-3-hours', $('Between 1 and 3 hours')),
@@ -1604,10 +1604,10 @@ go.app = function() {
         // ChoiceState
         self.add('state_servicerating_question4', function(name) {
             //var q_id = '4';
-            var q_text_en = "Was the facility clean?";
+            var q_text_en = $("Was the facility clean?");
 
             return new ChoiceState(name, {
-                question: $(q_text_en),
+                question: q_text_en,
                 choices: [
                     new Choice('very-satisfied', $('Very Satisfied')),
                     new Choice('satisfied', $('Satisfied')),
@@ -1621,10 +1621,10 @@ go.app = function() {
         // ChoiceState
         self.add('state_servicerating_question5', function(name) {
             //var q_id = '5';
-            var q_text_en = "Did you feel that your privacy was respected by the staff?";
+            var q_text_en = $("Did you feel that your privacy was respected by the staff?");
 
             return new ChoiceState(name, {
-                question: $(q_text_en),
+                question: q_text_en,
                 choices: [
                     new Choice('very-satisfied', $('Very Satisfied')),
                     new Choice('satisfied', $('Satisfied')),

--- a/go-app-ussd_public.js
+++ b/go-app-ussd_public.js
@@ -878,7 +878,7 @@ go.utils_project = {
         return go.utils
             .get_identity_by_address(address, im)
             .then(function(identity) {
-                return identity.servicerating_unanswered;
+                return identity.details.servicerating_unanswered;
             });
     },
 
@@ -1043,7 +1043,17 @@ go.app = function() {
                         } else {
                             self.im.user.set_answer('mother_id', user.details.mother_id);
                         }
-                        return self.states.create('state_permission');
+
+                        var msisdn = go.utils.normalize_msisdn(
+                            self.im.user.addr, self.im.config.country_code);
+
+                        return go.utils_project
+                            .check_servicerating_status({'msisdn': msisdn}, self.im)
+                            .then(function(servicerating_unanswered) {
+                                return servicerating_unanswered
+                                        ? self.states.create('state_servicerating_question1')
+                                        : self.states.create('state_permission');
+                            });
                     } else {
                         self.im.user.set_answer('role', 'guest');
                         return self.states.create('state_language');
@@ -1534,6 +1544,102 @@ go.app = function() {
                 : $(questions[name]).context({health_id: self.im.user.answers.health_id});
             return new EndState(name, {
                 text: text,
+                next: 'state_start'
+            });
+        });
+
+    // REGISTRATION STATES
+
+        // ChoiceState
+        self.add('state_servicerating_question1', function(name) {
+            //var q_id = '1';
+            var q_text_en = "Welcome. When you signed up, were staff at the facility friendly & helpful?";
+
+            return new ChoiceState(name, {
+                question: $(q_text_en),
+                choices: [
+                    new Choice('very-satisfied', $('Very Satisfied')),
+                    new Choice('satisfied', $('Satisfied')),
+                    new Choice('not-satisfied', $('Not Satisfied')),
+                    new Choice('very-unsatisfied', $('Very unsatisfied'))
+                ],
+                next: 'state_servicerating_question2'
+            });
+        });
+
+        // ChoiceState
+        self.add('state_servicerating_question2', function(name) {
+            //var q_id = '2';
+            var q_text_en = "How do you feel about the time you had to wait at the facility?";
+
+            return new ChoiceState(name, {
+                question: $(q_text_en),
+                choices: [
+                    new Choice('very-satisfied', $('Very Satisfied')),
+                    new Choice('satisfied', $('Satisfied')),
+                    new Choice('not-satisfied', $('Not Satisfied')),
+                    new Choice('very-unsatisfied', $('Very unsatisfied'))
+                ],
+                next: 'state_servicerating_question3'
+            });
+        });
+
+        // ChoiceState
+        self.add('state_servicerating_question3', function(name) {
+            //var q_id = '3';
+            var q_text_en = "How long did you wait to be helped at the clinic?";
+
+            return new ChoiceState(name, {
+                question: $(q_text_en),
+                choices: [
+                    new Choice('less-than-an-hour', $('Less than an hour')),
+                    new Choice('between-1-and-3-hours', $('Between 1 and 3 hours')),
+                    new Choice('more-than-4-hours', $('More than 4 hours')),
+                    new Choice('all-day', $('All day'))
+                ],
+                next: 'state_servicerating_question4'
+            });
+        });
+
+        // ChoiceState
+        self.add('state_servicerating_question4', function(name) {
+            //var q_id = '4';
+            var q_text_en = "Was the facility clean?";
+
+            return new ChoiceState(name, {
+                question: $(q_text_en),
+                choices: [
+                    new Choice('very-satisfied', $('Very Satisfied')),
+                    new Choice('satisfied', $('Satisfied')),
+                    new Choice('not-satisfied', $('Not Satisfied')),
+                    new Choice('very-unsatisfied', $('Very unsatisfied'))
+                ],
+                next: 'state_servicerating_question5'
+            });
+        });
+
+        // ChoiceState
+        self.add('state_servicerating_question5', function(name) {
+            //var q_id = '5';
+            var q_text_en = "Did you feel that your privacy was respected by the staff?";
+
+            return new ChoiceState(name, {
+                question: $(q_text_en),
+                choices: [
+                    new Choice('very-satisfied', $('Very Satisfied')),
+                    new Choice('satisfied', $('Satisfied')),
+                    new Choice('not-satisfied', $('Not Satisfied')),
+                    new Choice('very-unsatisfied', $('Very unsatisfied'))
+                ],
+                next: 'state_end_servicerating'
+            });
+        });
+
+        // EndState
+        self.add('state_end_servicerating', function(name) {
+            // set servicerating_unanswered flag to false...
+            return new EndState(name, {
+                text: $("Thank you for rating the FamilyConnect service."),
                 next: 'state_start'
             });
         });

--- a/src/ussd_public.js
+++ b/src/ussd_public.js
@@ -156,7 +156,17 @@ go.app = function() {
                         } else {
                             self.im.user.set_answer('mother_id', user.details.mother_id);
                         }
-                        return self.states.create('state_permission');
+
+                        var msisdn = go.utils.normalize_msisdn(
+                            self.im.user.addr, self.im.config.country_code);
+
+                        return go.utils_project
+                            .check_servicerating_status({'msisdn': msisdn}, self.im)
+                            .then(function(servicerating_unanswered) {
+                                return servicerating_unanswered
+                                        ? self.states.create('state_servicerating_question1')
+                                        : self.states.create('state_permission');
+                            });
                     } else {
                         self.im.user.set_answer('role', 'guest');
                         return self.states.create('state_language');
@@ -647,6 +657,102 @@ go.app = function() {
                 : $(questions[name]).context({health_id: self.im.user.answers.health_id});
             return new EndState(name, {
                 text: text,
+                next: 'state_start'
+            });
+        });
+
+    // REGISTRATION STATES
+
+        // ChoiceState
+        self.add('state_servicerating_question1', function(name) {
+            //var q_id = '1';
+            var q_text_en = "Welcome. When you signed up, were staff at the facility friendly & helpful?";
+
+            return new ChoiceState(name, {
+                question: $(q_text_en),
+                choices: [
+                    new Choice('very-satisfied', $('Very Satisfied')),
+                    new Choice('satisfied', $('Satisfied')),
+                    new Choice('not-satisfied', $('Not Satisfied')),
+                    new Choice('very-unsatisfied', $('Very unsatisfied'))
+                ],
+                next: 'state_servicerating_question2'
+            });
+        });
+
+        // ChoiceState
+        self.add('state_servicerating_question2', function(name) {
+            //var q_id = '2';
+            var q_text_en = "How do you feel about the time you had to wait at the facility?";
+
+            return new ChoiceState(name, {
+                question: $(q_text_en),
+                choices: [
+                    new Choice('very-satisfied', $('Very Satisfied')),
+                    new Choice('satisfied', $('Satisfied')),
+                    new Choice('not-satisfied', $('Not Satisfied')),
+                    new Choice('very-unsatisfied', $('Very unsatisfied'))
+                ],
+                next: 'state_servicerating_question3'
+            });
+        });
+
+        // ChoiceState
+        self.add('state_servicerating_question3', function(name) {
+            //var q_id = '3';
+            var q_text_en = "How long did you wait to be helped at the clinic?";
+
+            return new ChoiceState(name, {
+                question: $(q_text_en),
+                choices: [
+                    new Choice('less-than-an-hour', $('Less than an hour')),
+                    new Choice('between-1-and-3-hours', $('Between 1 and 3 hours')),
+                    new Choice('more-than-4-hours', $('More than 4 hours')),
+                    new Choice('all-day', $('All day'))
+                ],
+                next: 'state_servicerating_question4'
+            });
+        });
+
+        // ChoiceState
+        self.add('state_servicerating_question4', function(name) {
+            //var q_id = '4';
+            var q_text_en = "Was the facility clean?";
+
+            return new ChoiceState(name, {
+                question: $(q_text_en),
+                choices: [
+                    new Choice('very-satisfied', $('Very Satisfied')),
+                    new Choice('satisfied', $('Satisfied')),
+                    new Choice('not-satisfied', $('Not Satisfied')),
+                    new Choice('very-unsatisfied', $('Very unsatisfied'))
+                ],
+                next: 'state_servicerating_question5'
+            });
+        });
+
+        // ChoiceState
+        self.add('state_servicerating_question5', function(name) {
+            //var q_id = '5';
+            var q_text_en = "Did you feel that your privacy was respected by the staff?";
+
+            return new ChoiceState(name, {
+                question: $(q_text_en),
+                choices: [
+                    new Choice('very-satisfied', $('Very Satisfied')),
+                    new Choice('satisfied', $('Satisfied')),
+                    new Choice('not-satisfied', $('Not Satisfied')),
+                    new Choice('very-unsatisfied', $('Very unsatisfied'))
+                ],
+                next: 'state_end_servicerating'
+            });
+        });
+
+        // EndState
+        self.add('state_end_servicerating', function(name) {
+            // set servicerating_unanswered flag to false...
+            return new EndState(name, {
+                text: $("Thank you for rating the FamilyConnect service."),
                 next: 'state_start'
             });
         });

--- a/src/ussd_public.js
+++ b/src/ussd_public.js
@@ -666,10 +666,10 @@ go.app = function() {
         // ChoiceState
         self.add('state_servicerating_question1', function(name) {
             //var q_id = '1';
-            var q_text_en = "Welcome. When you signed up, were staff at the facility friendly & helpful?";
+            var q_text_en = $("Welcome. When you signed up, were staff at the facility friendly & helpful?");
 
             return new ChoiceState(name, {
-                question: $(q_text_en),
+                question: q_text_en,
                 choices: [
                     new Choice('very-satisfied', $('Very Satisfied')),
                     new Choice('satisfied', $('Satisfied')),
@@ -683,10 +683,10 @@ go.app = function() {
         // ChoiceState
         self.add('state_servicerating_question2', function(name) {
             //var q_id = '2';
-            var q_text_en = "How do you feel about the time you had to wait at the facility?";
+            var q_text_en = $("How do you feel about the time you had to wait at the facility?");
 
             return new ChoiceState(name, {
-                question: $(q_text_en),
+                question: q_text_en,
                 choices: [
                     new Choice('very-satisfied', $('Very Satisfied')),
                     new Choice('satisfied', $('Satisfied')),
@@ -700,10 +700,10 @@ go.app = function() {
         // ChoiceState
         self.add('state_servicerating_question3', function(name) {
             //var q_id = '3';
-            var q_text_en = "How long did you wait to be helped at the clinic?";
+            var q_text_en = $("How long did you wait to be helped at the clinic?");
 
             return new ChoiceState(name, {
-                question: $(q_text_en),
+                question: q_text_en,
                 choices: [
                     new Choice('less-than-an-hour', $('Less than an hour')),
                     new Choice('between-1-and-3-hours', $('Between 1 and 3 hours')),
@@ -717,10 +717,10 @@ go.app = function() {
         // ChoiceState
         self.add('state_servicerating_question4', function(name) {
             //var q_id = '4';
-            var q_text_en = "Was the facility clean?";
+            var q_text_en = $("Was the facility clean?");
 
             return new ChoiceState(name, {
-                question: $(q_text_en),
+                question: q_text_en,
                 choices: [
                     new Choice('very-satisfied', $('Very Satisfied')),
                     new Choice('satisfied', $('Satisfied')),
@@ -734,10 +734,10 @@ go.app = function() {
         // ChoiceState
         self.add('state_servicerating_question5', function(name) {
             //var q_id = '5';
-            var q_text_en = "Did you feel that your privacy was respected by the staff?";
+            var q_text_en = $("Did you feel that your privacy was respected by the staff?");
 
             return new ChoiceState(name, {
-                question: $(q_text_en),
+                question: q_text_en,
                 choices: [
                     new Choice('very-satisfied', $('Very Satisfied')),
                     new Choice('satisfied', $('Satisfied')),

--- a/src/utils_project.js
+++ b/src/utils_project.js
@@ -380,7 +380,7 @@ go.utils_project = {
         return go.utils
             .get_identity_by_address(address, im)
             .then(function(identity) {
-                return identity.servicerating_unanswered;
+                return identity.details.servicerating_unanswered;
             });
     },
 

--- a/src/utils_project.js
+++ b/src/utils_project.js
@@ -373,5 +373,16 @@ go.utils_project = {
         }
     },
 
+    // SERVICERATING HELPERS
+
+    // returns true if service rating unanswered
+    check_servicerating_status: function(address, im) {
+        return go.utils
+            .get_identity_by_address(address, im)
+            .then(function(identity) {
+                return identity.servicerating_unanswered;
+            });
+    },
+
     "commas": "commas"
 };

--- a/test/fixtures_public.js
+++ b/test/fixtures_public.js
@@ -5,6 +5,7 @@
 // 0720000444: change number - new number
 // 0720000555: unregistered user - number entered manually - mother_to_be registration
 // 0720000666: registered user - has baby(postbirth) subscription
+// 0720000777: registered user - servicerating_unanswered flag set to true
 
 module.exports = function() {
 return [
@@ -109,7 +110,7 @@ return [
                         },
                         "role": "mother",
                         "preferred_msg_type": "sms",
-                        "preferred_language": "eng_UG"
+                        "preferred_language": "eng_UG",
                     },
                     "created_at": "2015-07-10T06:13:29.693272Z",
                     "updated_at": "2015-07-10T06:13:29.693298Z"
@@ -1259,6 +1260,49 @@ return [
             'code': 201,
             'data': {
                 'id': 1
+            }
+        }
+    },
+
+    // 39: get identity 0720000222 by msisdn
+    {
+        'repeatable': true,
+        'request': {
+            'method': 'GET',
+            'params': {
+                'details__addresses__msisdn': '+256720000777'
+            },
+            'headers': {
+                'Authorization': ['Token test_key'],
+                'Content-Type': ['application/json']
+            },
+            'url': 'http://localhost:8001/api/v1/identities/search/',
+        },
+        'response': {
+            "code": 200,
+            "data": {
+                "count": 1,
+                "next": null,
+                "previous": null,
+                "results": [{
+                    "url": "http://localhost:8001/api/v1/identities/3f7c8851-5204-43f7-af7f-000000000777/",
+                    "id": "3f7c8851-5204-43f7-af7f-000000000777",
+                    "version": 1,
+                    "details": {
+                        "default_addr_type": "msisdn",
+                        "addresses": {
+                            "msisdn": {
+                                "+256720000222": {}
+                            }
+                        },
+                        "role": "mother",
+                        "preferred_msg_type": "sms",
+                        "preferred_language": "eng_UG",
+                        "servicerating_unanswered": true
+                    },
+                    "created_at": "2015-07-10T06:13:29.693272Z",
+                    "updated_at": "2015-07-10T06:13:29.693298Z"
+                }]
             }
         }
     },

--- a/test/ussd_public.test.js
+++ b/test/ussd_public.test.js
@@ -814,6 +814,130 @@ describe("familyconnect health worker app", function() {
             });
         });
 
+        // TEST SERVICERATING FLOW
+
+        describe("Servicerating testing", function() {
+            it("to state_servicerating_question1", function() {
+                return tester
+                    .setup.user.addr('0720000777')
+                    .inputs(
+                        {session_event: 'new'}  // dial in
+                    )
+                    .check.interaction({
+                        state: 'state_servicerating_question1',
+                        reply: [
+                            'Welcome. When you signed up, were staff at the facility friendly & helpful?',
+                            '1. Very Satisfied',
+                            '2. Satisfied',
+                            '3. Not Satisfied',
+                            '4. Very unsatisfied'
+                        ].join('\n')
+                    })
+                    .run();
+            });
+            it("to state_servicerating_question2", function() {
+                return tester
+                    .setup.user.addr('0720000777')
+                    .inputs(
+                        {session_event: 'new'}  // dial in
+                        , '2'  // state_servicerating_question1 - satisfied
+                    )
+                    .check.interaction({
+                        state: 'state_servicerating_question2',
+                        reply: [
+                            'How do you feel about the time you had to wait at the facility?',
+                            '1. Very Satisfied',
+                            '2. Satisfied',
+                            '3. Not Satisfied',
+                            '4. Very unsatisfied'
+                        ].join('\n')
+                    })
+                    .run();
+            });
+            it("to state_servicerating_question3", function() {
+                return tester
+                    .setup.user.addr('0720000777')
+                    .inputs(
+                        {session_event: 'new'}  // dial in
+                        , '2'  // state_servicerating_question1 - satisfied
+                        , '2'  // state_servicerating_question2 - satisfied
+                    )
+                    .check.interaction({
+                        state: 'state_servicerating_question3',
+                        reply: [
+                            'How long did you wait to be helped at the clinic?',
+                            '1. Less than an hour',
+                            '2. Between 1 and 3 hours',
+                            '3. More than 4 hours',
+                            '4. All day'
+                        ].join('\n')
+                    })
+                    .run();
+            });
+            it("to state_servicerating_question4", function() {
+                return tester
+                    .setup.user.addr('0720000777')
+                    .inputs(
+                        {session_event: 'new'}  // dial in
+                        , '2'  // state_servicerating_question1 - satisfied
+                        , '2'  // state_servicerating_question2 - satisfied
+                        , '3'  // state_servicerating_question3 - more than 4hours
+                    )
+                    .check.interaction({
+                        state: 'state_servicerating_question4',
+                        reply: [
+                            'Was the facility clean?',
+                            '1. Very Satisfied',
+                            '2. Satisfied',
+                            '3. Not Satisfied',
+                            '4. Very unsatisfied'
+                        ].join('\n')
+                    })
+                    .run();
+            });
+            it("to state_servicerating_question5", function() {
+                return tester
+                    .setup.user.addr('0720000777')
+                    .inputs(
+                        {session_event: 'new'}  // dial in
+                        , '2'  // state_servicerating_question1 - satisfied
+                        , '2'  // state_servicerating_question2 - satisfied
+                        , '3'  // state_servicerating_question3 - more than 4hours
+                        , '4'  // state_servicerating_question4 - very unsatisfied
+                    )
+                    .check.interaction({
+                        state: 'state_servicerating_question5',
+                        reply: [
+                            'Did you feel that your privacy was respected by the staff?',
+                            '1. Very Satisfied',
+                            '2. Satisfied',
+                            '3. Not Satisfied',
+                            '4. Very unsatisfied'
+                        ].join('\n')
+                    })
+                    .run();
+            });
+
+            it("to state_end_servicerating", function() {
+                return tester
+                    .setup.user.addr('0720000777')
+                    .inputs(
+                        {session_event: 'new'}  // dial in
+                        , '2'  // state_servicerating_question1 - satisfied
+                        , '2'  // state_servicerating_question2 - satisfied
+                        , '3'  // state_servicerating_question3 - more than 4hours
+                        , '4'  // state_servicerating_question4 - very unsatisfied
+                        , '1'  // state_servicerating_question5 - very satisfied
+                    )
+                    .check.interaction({
+                        state: 'state_end_servicerating',
+                        reply: "Thank you for rating the FamilyConnect service."
+                    })
+                    .check.reply.ends_session()
+                    .run();
+            });
+        });
+
     });
 
 });

--- a/test/ussd_public.test.js
+++ b/test/ussd_public.test.js
@@ -833,6 +833,9 @@ describe("familyconnect health worker app", function() {
                             '4. Very unsatisfied'
                         ].join('\n')
                     })
+                    .check(function(api) {
+                        go.utils.check_fixtures_used(api, [39]);
+                    })
                     .run();
             });
             it("to state_servicerating_question2", function() {
@@ -851,6 +854,9 @@ describe("familyconnect health worker app", function() {
                             '3. Not Satisfied',
                             '4. Very unsatisfied'
                         ].join('\n')
+                    })
+                    .check(function(api) {
+                        go.utils.check_fixtures_used(api, [39]);
                     })
                     .run();
             });
@@ -872,6 +878,9 @@ describe("familyconnect health worker app", function() {
                             '4. All day'
                         ].join('\n')
                     })
+                    .check(function(api) {
+                        go.utils.check_fixtures_used(api, [39]);
+                    })
                     .run();
             });
             it("to state_servicerating_question4", function() {
@@ -892,6 +901,9 @@ describe("familyconnect health worker app", function() {
                             '3. Not Satisfied',
                             '4. Very unsatisfied'
                         ].join('\n')
+                    })
+                    .check(function(api) {
+                        go.utils.check_fixtures_used(api, [39]);
                     })
                     .run();
             });
@@ -915,6 +927,9 @@ describe("familyconnect health worker app", function() {
                             '4. Very unsatisfied'
                         ].join('\n')
                     })
+                    .check(function(api) {
+                        go.utils.check_fixtures_used(api, [39]);
+                    })
                     .run();
             });
 
@@ -932,6 +947,9 @@ describe("familyconnect health worker app", function() {
                     .check.interaction({
                         state: 'state_end_servicerating',
                         reply: "Thank you for rating the FamilyConnect service."
+                    })
+                    .check(function(api) {
+                        go.utils.check_fixtures_used(api, [39]);
                     })
                     .check.reply.ends_session()
                     .run();

--- a/test/ussd_public.test.js
+++ b/test/ussd_public.test.js
@@ -816,7 +816,7 @@ describe("familyconnect health worker app", function() {
 
         // TEST SERVICERATING FLOW
 
-        describe("Servicerating testing", function() {
+        describe("Service Rating testing", function() {
             it("to state_servicerating_question1", function() {
                 return tester
                     .setup.user.addr('0720000777')


### PR DESCRIPTION
Add necessary flow/states to enable servicerating questions to be asked.
At start state check if identity exists and whether servicerating_unanswered flag is set to true.  Do this in a utils function.  If this is the case, direct to servicerating part of public app.  
Use namespace state_servicerating_questionX, where X is 1,2,3...
Include a q_id (question id) variable to each question state, as well as a variable with the question text.
For testing, also logically separate servicerating tests
