### PR TITLE
USSD Public - lookup service rating status instead of contact

### DIFF
--- a/go-app-sms.js
+++ b/go-app-sms.js
@@ -898,7 +898,7 @@ go.utils_project = {
         };
 
         return go.utils
-            .service_api_call("service_rating", "post", null, payload, "service_rating/", im)
+            .service_api_call("service_rating", "post", null, payload, "rating/", im)
             .then(function(response) {
                 return response;
             });

--- a/go-app-sms.js
+++ b/go-app-sms.js
@@ -882,6 +882,20 @@ go.utils_project = {
             });
     },
 
+    // saves service rating info and sets servicerating_unanswered flag
+    save_servicerating_info: function(identity_id, im) {
+        return go.utils
+            .get_identity(identity_id, im)
+            .then(function(identity) {
+                identity.details.question1 = im.user.answers.state_servicerating_question1;
+                identity.details.question2 = im.user.answers.state_servicerating_question2;
+                identity.details.question3 = im.user.answers.state_servicerating_question3;
+                identity.details.question4 = im.user.answers.state_servicerating_question4;
+                identity.details.question5 = im.user.answers.state_servicerating_question5;
+                identity.details.servicerating_unanswered = false;
+            });
+    },
+
     "commas": "commas"
 };
 

--- a/go-app-sms.js
+++ b/go-app-sms.js
@@ -873,16 +873,12 @@ go.utils_project = {
 
     // SERVICERATING HELPERS
 
-    // ...
-    check_servicerating_status: function(identity, im) {
-        var endpoint = 'invite/';
+    // get service rating status / invite
+    get_servicerating_status: function(identity, im) {
+        var endpoint = 'invite/'+identity+'/';
         return go.utils
             .service_api_call("service_rating", "get", null, null, endpoint, im)
             .then(function(json_get_response) {
-                /*console.log("***");
-                util = require("util");
-                var data = util.inspect(json_get_response);
-                console.log(data);*/
                 return json_get_response.data;
             });
     },

--- a/go-app-sms.js
+++ b/go-app-sms.js
@@ -882,19 +882,24 @@ go.utils_project = {
             });
     },
 
-    // saves service rating info and sets servicerating_unanswered flag
-    save_servicerating_info: function(identity_id, im) {
+    // saves servicerating info
+    post_servicerating_feedback: function(im, q_id, q_text, answer_text, answer_value) {
+        var payload = {
+            "identity_id": im.user.answers.user_id,
+            "question_id": q_id,
+            "question_text": q_text,
+            "answer_text": answer_text,
+            "answer_value": answer_value
+        };
+
         return go.utils
-            .get_identity(identity_id, im)
-            .then(function(identity) {
-                identity.details.question1 = im.user.answers.state_servicerating_question1;
-                identity.details.question2 = im.user.answers.state_servicerating_question2;
-                identity.details.question3 = im.user.answers.state_servicerating_question3;
-                identity.details.question4 = im.user.answers.state_servicerating_question4;
-                identity.details.question5 = im.user.answers.state_servicerating_question5;
-                identity.details.servicerating_unanswered = false;
+            .service_api_call("servicerating", "post", null, payload, "servicerating/", im)
+            .then(function(response) {
+                return response;
             });
     },
+
+
 
     "commas": "commas"
 };

--- a/go-app-sms.js
+++ b/go-app-sms.js
@@ -877,8 +877,8 @@ go.utils_project = {
     check_servicerating_status: function(identity, im) {
         var params = {
             "identity": identity,
-            "completed": 'False',
-            "expired": 'False'
+            "completed": "False",
+            "expired": "False"
         };
         return go.utils
             .service_api_call("service_rating", "get", params, null, "invite/", im)
@@ -910,7 +910,7 @@ go.utils_project = {
     set_servicerating_status_completed: function(im) {
         var endpoint = "invite/"+im.user.answers.invite_uuid+"/";
         var payload = {
-            "completed": 'True'
+            "completed": "True"
         };
 
         return go.utils

--- a/go-app-sms.js
+++ b/go-app-sms.js
@@ -873,8 +873,7 @@ go.utils_project = {
 
     // SERVICERATING HELPERS
 
-    // check service rating status
-
+    // check for service rating status not completed yet
     check_servicerating_status: function(identity, im) {
         var params = {
             "identity": identity,
@@ -907,6 +906,19 @@ go.utils_project = {
             });
     },
 
+    // sets service rating 'completed' to true
+    set_servicerating_status_completed: function(im) {
+        var endpoint = "invite/"+im.user.answers.invite_uuid+"/";
+        var payload = {
+            "completed": 'True'
+        };
+
+        return go.utils
+            .service_api_call("service_rating", "patch", null, payload, endpoint, im)
+            .then(function(response) {
+                return response;
+            });
+    },
 
 
     "commas": "commas"

--- a/go-app-sms.js
+++ b/go-app-sms.js
@@ -898,7 +898,7 @@ go.utils_project = {
         };
 
         return go.utils
-            .service_api_call("rating", "post", null, payload, "rating/", im)
+            .service_api_call("service_rating", "post", null, payload, "service_rating/", im)
             .then(function(response) {
                 return response;
             });

--- a/go-app-sms.js
+++ b/go-app-sms.js
@@ -884,9 +884,6 @@ go.utils_project = {
         return go.utils
             .service_api_call("service_rating", "get", params, null, "invite/", im)
             .then(function(json_get_response) {
-                /*util = require('util');
-                var dataObj = util.inspect(json_get_response.data);
-                console.log(dataObj);*/
                 return json_get_response.data;
             });
     },

--- a/go-app-sms.js
+++ b/go-app-sms.js
@@ -873,12 +873,20 @@ go.utils_project = {
 
     // SERVICERATING HELPERS
 
-    // get service rating status / invite
-    get_servicerating_status: function(identity, im) {
-        var endpoint = 'invite/'+identity+'/';
+    // check service rating status
+
+    check_servicerating_status: function(identity, im) {
+        var params = {
+            "identity": identity,
+            "completed": false,
+            "expired": false
+        };
         return go.utils
-            .service_api_call("service_rating", "get", null, null, endpoint, im)
+            .service_api_call("service_rating", "get", params, null, "invite/", im)
             .then(function(json_get_response) {
+                /*util = require('util');
+                var dataObj = util.inspect(json_get_response.data);
+                console.log(dataObj);*/
                 return json_get_response.data;
             });
     },

--- a/go-app-sms.js
+++ b/go-app-sms.js
@@ -878,14 +878,19 @@ go.utils_project = {
         return go.utils
             .get_identity_by_address(address, im)
             .then(function(identity) {
-                return identity.details.servicerating_unanswered;
+                return {
+                    unanswered: identity.details.servicerating_unanswered,
+                    invite_uuid: identity.details.invite,
+                };
             });
     },
 
     // saves servicerating info
-    post_servicerating_feedback: function(im, q_id, q_text, answer_text, answer_value) {
+    post_servicerating_feedback: function(im, q_id, q_text, answer_text, answer_value, version_number, invite_uuid) {
         var payload = {
             "identity_id": im.user.answers.user_id,
+            "invite": invite_uuid,
+            "version": version_number,
             "question_id": q_id,
             "question_text": q_text,
             "answer_text": answer_text,
@@ -893,7 +898,7 @@ go.utils_project = {
         };
 
         return go.utils
-            .service_api_call("servicerating", "post", null, payload, "servicerating/", im)
+            .service_api_call("rating", "post", null, payload, "rating/", im)
             .then(function(response) {
                 return response;
             });

--- a/go-app-sms.js
+++ b/go-app-sms.js
@@ -878,8 +878,8 @@ go.utils_project = {
     check_servicerating_status: function(identity, im) {
         var params = {
             "identity": identity,
-            "completed": false,
-            "expired": false
+            "completed": 'False',
+            "expired": 'False'
         };
         return go.utils
             .service_api_call("service_rating", "get", params, null, "invite/", im)

--- a/go-app-sms.js
+++ b/go-app-sms.js
@@ -873,15 +873,17 @@ go.utils_project = {
 
     // SERVICERATING HELPERS
 
-    // returns true if service rating unanswered
-    check_servicerating_status: function(address, im) {
+    // ...
+    check_servicerating_status: function(identity, im) {
+        var endpoint = 'invite/';
         return go.utils
-            .get_identity_by_address(address, im)
-            .then(function(identity) {
-                return {
-                    unanswered: identity.details.servicerating_unanswered,
-                    invite_uuid: identity.details.invite,
-                };
+            .service_api_call("service_rating", "get", null, null, endpoint, im)
+            .then(function(json_get_response) {
+                /*console.log("***");
+                util = require("util");
+                var data = util.inspect(json_get_response);
+                console.log(data);*/
+                return json_get_response.data;
             });
     },
 

--- a/go-app-sms.js
+++ b/go-app-sms.js
@@ -888,7 +888,7 @@ go.utils_project = {
     // saves servicerating info
     post_servicerating_feedback: function(im, q_id, q_text, answer_text, answer_value, version_number, invite_uuid) {
         var payload = {
-            "identity_id": im.user.answers.user_id,
+            "identity": im.user.answers.user_id,
             "invite": invite_uuid,
             "version": version_number,
             "question_id": q_id,

--- a/go-app-ussd_health_worker.js
+++ b/go-app-ussd_health_worker.js
@@ -898,7 +898,7 @@ go.utils_project = {
         };
 
         return go.utils
-            .service_api_call("service_rating", "post", null, payload, "service_rating/", im)
+            .service_api_call("service_rating", "post", null, payload, "rating/", im)
             .then(function(response) {
                 return response;
             });

--- a/go-app-ussd_health_worker.js
+++ b/go-app-ussd_health_worker.js
@@ -882,6 +882,20 @@ go.utils_project = {
             });
     },
 
+    // saves service rating info and sets servicerating_unanswered flag
+    save_servicerating_info: function(identity_id, im) {
+        return go.utils
+            .get_identity(identity_id, im)
+            .then(function(identity) {
+                identity.details.question1 = im.user.answers.state_servicerating_question1;
+                identity.details.question2 = im.user.answers.state_servicerating_question2;
+                identity.details.question3 = im.user.answers.state_servicerating_question3;
+                identity.details.question4 = im.user.answers.state_servicerating_question4;
+                identity.details.question5 = im.user.answers.state_servicerating_question5;
+                identity.details.servicerating_unanswered = false;
+            });
+    },
+
     "commas": "commas"
 };
 

--- a/go-app-ussd_health_worker.js
+++ b/go-app-ussd_health_worker.js
@@ -873,16 +873,12 @@ go.utils_project = {
 
     // SERVICERATING HELPERS
 
-    // ...
-    check_servicerating_status: function(identity, im) {
-        var endpoint = 'invite/';
+    // get service rating status / invite
+    get_servicerating_status: function(identity, im) {
+        var endpoint = 'invite/'+identity+'/';
         return go.utils
             .service_api_call("service_rating", "get", null, null, endpoint, im)
             .then(function(json_get_response) {
-                /*console.log("***");
-                util = require("util");
-                var data = util.inspect(json_get_response);
-                console.log(data);*/
                 return json_get_response.data;
             });
     },

--- a/go-app-ussd_health_worker.js
+++ b/go-app-ussd_health_worker.js
@@ -882,19 +882,24 @@ go.utils_project = {
             });
     },
 
-    // saves service rating info and sets servicerating_unanswered flag
-    save_servicerating_info: function(identity_id, im) {
+    // saves servicerating info
+    post_servicerating_feedback: function(im, q_id, q_text, answer_text, answer_value) {
+        var payload = {
+            "identity_id": im.user.answers.user_id,
+            "question_id": q_id,
+            "question_text": q_text,
+            "answer_text": answer_text,
+            "answer_value": answer_value
+        };
+
         return go.utils
-            .get_identity(identity_id, im)
-            .then(function(identity) {
-                identity.details.question1 = im.user.answers.state_servicerating_question1;
-                identity.details.question2 = im.user.answers.state_servicerating_question2;
-                identity.details.question3 = im.user.answers.state_servicerating_question3;
-                identity.details.question4 = im.user.answers.state_servicerating_question4;
-                identity.details.question5 = im.user.answers.state_servicerating_question5;
-                identity.details.servicerating_unanswered = false;
+            .service_api_call("servicerating", "post", null, payload, "servicerating/", im)
+            .then(function(response) {
+                return response;
             });
     },
+
+
 
     "commas": "commas"
 };

--- a/go-app-ussd_health_worker.js
+++ b/go-app-ussd_health_worker.js
@@ -877,8 +877,8 @@ go.utils_project = {
     check_servicerating_status: function(identity, im) {
         var params = {
             "identity": identity,
-            "completed": 'False',
-            "expired": 'False'
+            "completed": "False",
+            "expired": "False"
         };
         return go.utils
             .service_api_call("service_rating", "get", params, null, "invite/", im)
@@ -910,7 +910,7 @@ go.utils_project = {
     set_servicerating_status_completed: function(im) {
         var endpoint = "invite/"+im.user.answers.invite_uuid+"/";
         var payload = {
-            "completed": 'True'
+            "completed": "True"
         };
 
         return go.utils

--- a/go-app-ussd_health_worker.js
+++ b/go-app-ussd_health_worker.js
@@ -873,8 +873,7 @@ go.utils_project = {
 
     // SERVICERATING HELPERS
 
-    // check service rating status
-
+    // check for service rating status not completed yet
     check_servicerating_status: function(identity, im) {
         var params = {
             "identity": identity,
@@ -907,6 +906,19 @@ go.utils_project = {
             });
     },
 
+    // sets service rating 'completed' to true
+    set_servicerating_status_completed: function(im) {
+        var endpoint = "invite/"+im.user.answers.invite_uuid+"/";
+        var payload = {
+            "completed": 'True'
+        };
+
+        return go.utils
+            .service_api_call("service_rating", "patch", null, payload, endpoint, im)
+            .then(function(response) {
+                return response;
+            });
+    },
 
 
     "commas": "commas"

--- a/go-app-ussd_health_worker.js
+++ b/go-app-ussd_health_worker.js
@@ -898,7 +898,7 @@ go.utils_project = {
         };
 
         return go.utils
-            .service_api_call("rating", "post", null, payload, "rating/", im)
+            .service_api_call("service_rating", "post", null, payload, "service_rating/", im)
             .then(function(response) {
                 return response;
             });

--- a/go-app-ussd_health_worker.js
+++ b/go-app-ussd_health_worker.js
@@ -884,9 +884,6 @@ go.utils_project = {
         return go.utils
             .service_api_call("service_rating", "get", params, null, "invite/", im)
             .then(function(json_get_response) {
-                /*util = require('util');
-                var dataObj = util.inspect(json_get_response.data);
-                console.log(dataObj);*/
                 return json_get_response.data;
             });
     },

--- a/go-app-ussd_health_worker.js
+++ b/go-app-ussd_health_worker.js
@@ -873,12 +873,20 @@ go.utils_project = {
 
     // SERVICERATING HELPERS
 
-    // get service rating status / invite
-    get_servicerating_status: function(identity, im) {
-        var endpoint = 'invite/'+identity+'/';
+    // check service rating status
+
+    check_servicerating_status: function(identity, im) {
+        var params = {
+            "identity": identity,
+            "completed": false,
+            "expired": false
+        };
         return go.utils
-            .service_api_call("service_rating", "get", null, null, endpoint, im)
+            .service_api_call("service_rating", "get", params, null, "invite/", im)
             .then(function(json_get_response) {
+                /*util = require('util');
+                var dataObj = util.inspect(json_get_response.data);
+                console.log(dataObj);*/
                 return json_get_response.data;
             });
     },

--- a/go-app-ussd_health_worker.js
+++ b/go-app-ussd_health_worker.js
@@ -878,14 +878,19 @@ go.utils_project = {
         return go.utils
             .get_identity_by_address(address, im)
             .then(function(identity) {
-                return identity.details.servicerating_unanswered;
+                return {
+                    unanswered: identity.details.servicerating_unanswered,
+                    invite_uuid: identity.details.invite,
+                };
             });
     },
 
     // saves servicerating info
-    post_servicerating_feedback: function(im, q_id, q_text, answer_text, answer_value) {
+    post_servicerating_feedback: function(im, q_id, q_text, answer_text, answer_value, version_number, invite_uuid) {
         var payload = {
             "identity_id": im.user.answers.user_id,
+            "invite": invite_uuid,
+            "version": version_number,
             "question_id": q_id,
             "question_text": q_text,
             "answer_text": answer_text,
@@ -893,7 +898,7 @@ go.utils_project = {
         };
 
         return go.utils
-            .service_api_call("servicerating", "post", null, payload, "servicerating/", im)
+            .service_api_call("rating", "post", null, payload, "rating/", im)
             .then(function(response) {
                 return response;
             });

--- a/go-app-ussd_health_worker.js
+++ b/go-app-ussd_health_worker.js
@@ -878,8 +878,8 @@ go.utils_project = {
     check_servicerating_status: function(identity, im) {
         var params = {
             "identity": identity,
-            "completed": false,
-            "expired": false
+            "completed": 'False',
+            "expired": 'False'
         };
         return go.utils
             .service_api_call("service_rating", "get", params, null, "invite/", im)

--- a/go-app-ussd_health_worker.js
+++ b/go-app-ussd_health_worker.js
@@ -873,15 +873,17 @@ go.utils_project = {
 
     // SERVICERATING HELPERS
 
-    // returns true if service rating unanswered
-    check_servicerating_status: function(address, im) {
+    // ...
+    check_servicerating_status: function(identity, im) {
+        var endpoint = 'invite/';
         return go.utils
-            .get_identity_by_address(address, im)
-            .then(function(identity) {
-                return {
-                    unanswered: identity.details.servicerating_unanswered,
-                    invite_uuid: identity.details.invite,
-                };
+            .service_api_call("service_rating", "get", null, null, endpoint, im)
+            .then(function(json_get_response) {
+                /*console.log("***");
+                util = require("util");
+                var data = util.inspect(json_get_response);
+                console.log(data);*/
+                return json_get_response.data;
             });
     },
 

--- a/go-app-ussd_health_worker.js
+++ b/go-app-ussd_health_worker.js
@@ -888,7 +888,7 @@ go.utils_project = {
     // saves servicerating info
     post_servicerating_feedback: function(im, q_id, q_text, answer_text, answer_value, version_number, invite_uuid) {
         var payload = {
-            "identity_id": im.user.answers.user_id,
+            "identity": im.user.answers.user_id,
             "invite": invite_uuid,
             "version": version_number,
             "question_id": q_id,

--- a/go-app-ussd_public.js
+++ b/go-app-ussd_public.js
@@ -898,7 +898,7 @@ go.utils_project = {
         };
 
         return go.utils
-            .service_api_call("service_rating", "post", null, payload, "service_rating/", im)
+            .service_api_call("service_rating", "post", null, payload, "rating/", im)
             .then(function(response) {
                 return response;
             });

--- a/go-app-ussd_public.js
+++ b/go-app-ussd_public.js
@@ -873,16 +873,12 @@ go.utils_project = {
 
     // SERVICERATING HELPERS
 
-    // ...
-    check_servicerating_status: function(identity, im) {
-        var endpoint = 'invite/';
+    // get service rating status / invite
+    get_servicerating_status: function(identity, im) {
+        var endpoint = 'invite/'+identity+'/';
         return go.utils
             .service_api_call("service_rating", "get", null, null, endpoint, im)
             .then(function(json_get_response) {
-                /*console.log("***");
-                util = require("util");
-                var data = util.inspect(json_get_response);
-                console.log(data);*/
                 return json_get_response.data;
             });
     },
@@ -1070,16 +1066,11 @@ go.app = function() {
                             self.im.user.set_answer('mother_id', user.details.mother_id);
                         }
 
-                        //var msisdn = go.utils.normalize_msisdn(
-                        //    self.im.user.addr, self.im.config.country_code);
-
                         return go.utils_project
-                            .check_servicerating_status(user.id, self.im)
+                            .get_servicerating_status(user.id, self.im)
                             .then(function(status_data) {
-                                self.im.user.set_answer('invite_uuid', status_data.id);
-                                console.log("ussd_public.js->state_start UUID: "+status_data.id/*status_data.details.id*/);
-                                console.log("ussd_public.js->state_start CHECK: "+status_data.expired+" "+status_data.completed);
-                                if (!status_data.expired && !status_data.completed) {
+                                self.im.user.set_answer('invite_uuid', status_data.details.id);
+                                if (!status_data.details.expired && !status_data.details.completed) {
                                     return self.states.create('state_servicerating_question1');
                                 }
                                 else {

--- a/go-app-ussd_public.js
+++ b/go-app-ussd_public.js
@@ -1077,8 +1077,8 @@ go.app = function() {
                         return go.utils_project
                             .check_servicerating_status(user.id, self.im)
                             .then(function(status_data) {
-                                if (status_data.results.id) {
-                                    self.im.user.set_answer('invite_uuid', status_data.results.id);
+                                if (status_data.results.length > 0) {
+                                    self.im.user.set_answer('invite_uuid', status_data.results[0].id);
                                     return self.states.create('state_servicerating_question1');
                                 }
                                 else {

--- a/go-app-ussd_public.js
+++ b/go-app-ussd_public.js
@@ -898,7 +898,7 @@ go.utils_project = {
         };
 
         return go.utils
-            .service_api_call("rating", "post", null, payload, "rating/", im)
+            .service_api_call("service_rating", "post", null, payload, "service_rating/", im)
             .then(function(response) {
                 return response;
             });

--- a/go-app-ussd_public.js
+++ b/go-app-ussd_public.js
@@ -884,9 +884,6 @@ go.utils_project = {
         return go.utils
             .service_api_call("service_rating", "get", params, null, "invite/", im)
             .then(function(json_get_response) {
-                /*util = require('util');
-                var dataObj = util.inspect(json_get_response.data);
-                console.log(dataObj);*/
                 return json_get_response.data;
             });
     },

--- a/go-app-ussd_public.js
+++ b/go-app-ussd_public.js
@@ -873,12 +873,20 @@ go.utils_project = {
 
     // SERVICERATING HELPERS
 
-    // get service rating status / invite
-    get_servicerating_status: function(identity, im) {
-        var endpoint = 'invite/'+identity+'/';
+    // check service rating status
+
+    check_servicerating_status: function(identity, im) {
+        var params = {
+            "identity": identity,
+            "completed": false,
+            "expired": false
+        };
         return go.utils
-            .service_api_call("service_rating", "get", null, null, endpoint, im)
+            .service_api_call("service_rating", "get", params, null, "invite/", im)
             .then(function(json_get_response) {
+                /*util = require('util');
+                var dataObj = util.inspect(json_get_response.data);
+                console.log(dataObj);*/
                 return json_get_response.data;
             });
     },
@@ -1067,10 +1075,10 @@ go.app = function() {
                         }
 
                         return go.utils_project
-                            .get_servicerating_status(user.id, self.im)
+                            .check_servicerating_status(user.id, self.im)
                             .then(function(status_data) {
-                                self.im.user.set_answer('invite_uuid', status_data.details.id);
-                                if (!status_data.details.expired && !status_data.details.completed) {
+                                if (status_data.details.id) {
+                                    self.im.user.set_answer('invite_uuid', status_data.details.id);
                                     return self.states.create('state_servicerating_question1');
                                 }
                                 else {

--- a/go-app-ussd_public.js
+++ b/go-app-ussd_public.js
@@ -882,6 +882,20 @@ go.utils_project = {
             });
     },
 
+    // saves service rating info and sets servicerating_unanswered flag
+    save_servicerating_info: function(identity_id, im) {
+        return go.utils
+            .get_identity(identity_id, im)
+            .then(function(identity) {
+                identity.details.question1 = im.user.answers.state_servicerating_question1;
+                identity.details.question2 = im.user.answers.state_servicerating_question2;
+                identity.details.question3 = im.user.answers.state_servicerating_question3;
+                identity.details.question4 = im.user.answers.state_servicerating_question4;
+                identity.details.question5 = im.user.answers.state_servicerating_question5;
+                identity.details.servicerating_unanswered = false;
+            });
+    },
+
     "commas": "commas"
 };
 
@@ -1548,9 +1562,9 @@ go.app = function() {
             });
         });
 
-    // REGISTRATION STATES
+    // SERVICERATING STATES
 
-        // ChoiceState
+        // ChoiceState 1
         self.add('state_servicerating_question1', function(name) {
             //var q_id = '1';
             var q_text_en = $("Welcome. When you signed up, were staff at the facility friendly & helpful?");
@@ -1567,7 +1581,7 @@ go.app = function() {
             });
         });
 
-        // ChoiceState
+        // ChoiceState 2
         self.add('state_servicerating_question2', function(name) {
             //var q_id = '2';
             var q_text_en = $("How do you feel about the time you had to wait at the facility?");
@@ -1584,7 +1598,7 @@ go.app = function() {
             });
         });
 
-        // ChoiceState
+        // ChoiceState 3
         self.add('state_servicerating_question3', function(name) {
             //var q_id = '3';
             var q_text_en = $("How long did you wait to be helped at the clinic?");
@@ -1601,7 +1615,7 @@ go.app = function() {
             });
         });
 
-        // ChoiceState
+        // ChoiceState 4
         self.add('state_servicerating_question4', function(name) {
             //var q_id = '4';
             var q_text_en = $("Was the facility clean?");
@@ -1618,7 +1632,7 @@ go.app = function() {
             });
         });
 
-        // ChoiceState
+        // ChoiceState 5
         self.add('state_servicerating_question5', function(name) {
             //var q_id = '5';
             var q_text_en = $("Did you feel that your privacy was respected by the staff?");
@@ -1635,7 +1649,7 @@ go.app = function() {
             });
         });
 
-        // EndState
+        // EndState 6
         self.add('state_end_servicerating', function(name) {
             // set servicerating_unanswered flag to false...
             return new EndState(name, {

--- a/go-app-ussd_public.js
+++ b/go-app-ussd_public.js
@@ -877,8 +877,8 @@ go.utils_project = {
     check_servicerating_status: function(identity, im) {
         var params = {
             "identity": identity,
-            "completed": 'False',
-            "expired": 'False'
+            "completed": "False",
+            "expired": "False"
         };
         return go.utils
             .service_api_call("service_rating", "get", params, null, "invite/", im)
@@ -910,7 +910,7 @@ go.utils_project = {
     set_servicerating_status_completed: function(im) {
         var endpoint = "invite/"+im.user.answers.invite_uuid+"/";
         var payload = {
-            "completed": 'True'
+            "completed": "True"
         };
 
         return go.utils
@@ -1710,9 +1710,7 @@ go.app = function() {
             return go.utils_project
                 .set_servicerating_status_completed(self.im)
                 .then(function(response) {
-                    if (response.code === 200) {
-                        return self.states.create('state_end_servicerating');
-                    }
+                    return self.states.create('state_end_servicerating');
                 });
         });
 

--- a/go-app-ussd_public.js
+++ b/go-app-ussd_public.js
@@ -878,8 +878,8 @@ go.utils_project = {
     check_servicerating_status: function(identity, im) {
         var params = {
             "identity": identity,
-            "completed": false,
-            "expired": false
+            "completed": 'False',
+            "expired": 'False'
         };
         return go.utils
             .service_api_call("service_rating", "get", params, null, "invite/", im)
@@ -1077,8 +1077,8 @@ go.app = function() {
                         return go.utils_project
                             .check_servicerating_status(user.id, self.im)
                             .then(function(status_data) {
-                                if (status_data.details.id) {
-                                    self.im.user.set_answer('invite_uuid', status_data.details.id);
+                                if (status_data.results.id) {
+                                    self.im.user.set_answer('invite_uuid', status_data.results.id);
                                     return self.states.create('state_servicerating_question1');
                                 }
                                 else {

--- a/go-app-ussd_public.js
+++ b/go-app-ussd_public.js
@@ -888,7 +888,7 @@ go.utils_project = {
     // saves servicerating info
     post_servicerating_feedback: function(im, q_id, q_text, answer_text, answer_value, version_number, invite_uuid) {
         var payload = {
-            "identity_id": im.user.answers.user_id,
+            "identity": im.user.answers.user_id,
             "invite": invite_uuid,
             "version": version_number,
             "question_id": q_id,

--- a/go-app-ussd_public.js
+++ b/go-app-ussd_public.js
@@ -882,19 +882,24 @@ go.utils_project = {
             });
     },
 
-    // saves service rating info and sets servicerating_unanswered flag
-    save_servicerating_info: function(identity_id, im) {
+    // saves servicerating info
+    post_servicerating_feedback: function(im, q_id, q_text, answer_text, answer_value) {
+        var payload = {
+            "identity_id": im.user.answers.user_id,
+            "question_id": q_id,
+            "question_text": q_text,
+            "answer_text": answer_text,
+            "answer_value": answer_value
+        };
+
         return go.utils
-            .get_identity(identity_id, im)
-            .then(function(identity) {
-                identity.details.question1 = im.user.answers.state_servicerating_question1;
-                identity.details.question2 = im.user.answers.state_servicerating_question2;
-                identity.details.question3 = im.user.answers.state_servicerating_question3;
-                identity.details.question4 = im.user.answers.state_servicerating_question4;
-                identity.details.question5 = im.user.answers.state_servicerating_question5;
-                identity.details.servicerating_unanswered = false;
+            .service_api_call("servicerating", "post", null, payload, "servicerating/", im)
+            .then(function(response) {
+                return response;
             });
     },
+
+
 
     "commas": "commas"
 };
@@ -1566,7 +1571,7 @@ go.app = function() {
 
         // ChoiceState 1
         self.add('state_servicerating_question1', function(name) {
-            //var q_id = '1';
+            var q_id = '1';
             var q_text_en = $("Welcome. When you signed up, were staff at the facility friendly & helpful?");
 
             return new ChoiceState(name, {
@@ -1577,13 +1582,19 @@ go.app = function() {
                     new Choice('not-satisfied', $('Not Satisfied')),
                     new Choice('very-unsatisfied', $('Very unsatisfied'))
                 ],
-                next: 'state_servicerating_question2'
+                next: function(choice) {
+                    return go.utils_project
+                        .post_servicerating_feedback(self.im, q_id, q_text_en.args[0], choice.label, choice.value)
+                        .then(function() {
+                            return 'state_servicerating_question2';
+                        });
+                }
             });
         });
 
         // ChoiceState 2
         self.add('state_servicerating_question2', function(name) {
-            //var q_id = '2';
+            var q_id = '2';
             var q_text_en = $("How do you feel about the time you had to wait at the facility?");
 
             return new ChoiceState(name, {
@@ -1594,13 +1605,19 @@ go.app = function() {
                     new Choice('not-satisfied', $('Not Satisfied')),
                     new Choice('very-unsatisfied', $('Very unsatisfied'))
                 ],
-                next: 'state_servicerating_question3'
+                next: function(choice) {
+                    return go.utils_project
+                        .post_servicerating_feedback(self.im, q_id, q_text_en.args[0], choice.label, choice.value)
+                        .then(function() {
+                            return 'state_servicerating_question3';
+                        });
+                }
             });
         });
 
         // ChoiceState 3
         self.add('state_servicerating_question3', function(name) {
-            //var q_id = '3';
+            var q_id = '3';
             var q_text_en = $("How long did you wait to be helped at the clinic?");
 
             return new ChoiceState(name, {
@@ -1611,13 +1628,19 @@ go.app = function() {
                     new Choice('more-than-4-hours', $('More than 4 hours')),
                     new Choice('all-day', $('All day'))
                 ],
-                next: 'state_servicerating_question4'
+                next: function(choice) {
+                    return go.utils_project
+                        .post_servicerating_feedback(self.im, q_id, q_text_en.args[0], choice.label, choice.value)
+                        .then(function() {
+                            return 'state_servicerating_question4';
+                        });
+                }
             });
         });
 
         // ChoiceState 4
         self.add('state_servicerating_question4', function(name) {
-            //var q_id = '4';
+            var q_id = '4';
             var q_text_en = $("Was the facility clean?");
 
             return new ChoiceState(name, {
@@ -1628,13 +1651,19 @@ go.app = function() {
                     new Choice('not-satisfied', $('Not Satisfied')),
                     new Choice('very-unsatisfied', $('Very unsatisfied'))
                 ],
-                next: 'state_servicerating_question5'
+                next: function(choice) {
+                    return go.utils_project
+                        .post_servicerating_feedback(self.im, q_id, q_text_en.args[0], choice.label, choice.value)
+                        .then(function() {
+                            return 'state_servicerating_question5';
+                        });
+                }
             });
         });
 
         // ChoiceState 5
         self.add('state_servicerating_question5', function(name) {
-            //var q_id = '5';
+            var q_id = '5';
             var q_text_en = $("Did you feel that your privacy was respected by the staff?");
 
             return new ChoiceState(name, {
@@ -1645,13 +1674,20 @@ go.app = function() {
                     new Choice('not-satisfied', $('Not Satisfied')),
                     new Choice('very-unsatisfied', $('Very unsatisfied'))
                 ],
-                next: 'state_end_servicerating'
+                next: function(choice) {
+                    return go.utils_project
+                        .post_servicerating_feedback(self.im, q_id, q_text_en.args[0], choice.label, choice.value)
+                        .then(function() {
+                            return 'state_end_servicerating';
+                        });
+                }
             });
         });
 
         // EndState 6
         self.add('state_end_servicerating', function(name) {
-            // set servicerating_unanswered flag to false...
+            // sets servicerating_unanswered to false indicating completed servicerating feedback
+            self.im.user.set_answer('servicerating_unanswered', false);
             return new EndState(name, {
                 text: $("Thank you for rating the FamilyConnect service."),
                 next: 'state_start'

--- a/src/ussd_public.js
+++ b/src/ussd_public.js
@@ -160,8 +160,8 @@ go.app = function() {
                         return go.utils_project
                             .check_servicerating_status(user.id, self.im)
                             .then(function(status_data) {
-                                if (status_data.results.id) {
-                                    self.im.user.set_answer('invite_uuid', status_data.results.id);
+                                if (status_data.results.length > 0) {
+                                    self.im.user.set_answer('invite_uuid', status_data.results[0].id);
                                     return self.states.create('state_servicerating_question1');
                                 }
                                 else {

--- a/src/ussd_public.js
+++ b/src/ussd_public.js
@@ -665,7 +665,7 @@ go.app = function() {
 
         // ChoiceState 1
         self.add('state_servicerating_question1', function(name) {
-            //var q_id = '1';
+            var q_id = '1';
             var q_text_en = $("Welcome. When you signed up, were staff at the facility friendly & helpful?");
 
             return new ChoiceState(name, {
@@ -676,13 +676,19 @@ go.app = function() {
                     new Choice('not-satisfied', $('Not Satisfied')),
                     new Choice('very-unsatisfied', $('Very unsatisfied'))
                 ],
-                next: 'state_servicerating_question2'
+                next: function(choice) {
+                    return go.utils_project
+                        .post_servicerating_feedback(self.im, q_id, q_text_en.args[0], choice.label, choice.value)
+                        .then(function() {
+                            return 'state_servicerating_question2';
+                        });
+                }
             });
         });
 
         // ChoiceState 2
         self.add('state_servicerating_question2', function(name) {
-            //var q_id = '2';
+            var q_id = '2';
             var q_text_en = $("How do you feel about the time you had to wait at the facility?");
 
             return new ChoiceState(name, {
@@ -693,13 +699,19 @@ go.app = function() {
                     new Choice('not-satisfied', $('Not Satisfied')),
                     new Choice('very-unsatisfied', $('Very unsatisfied'))
                 ],
-                next: 'state_servicerating_question3'
+                next: function(choice) {
+                    return go.utils_project
+                        .post_servicerating_feedback(self.im, q_id, q_text_en.args[0], choice.label, choice.value)
+                        .then(function() {
+                            return 'state_servicerating_question3';
+                        });
+                }
             });
         });
 
         // ChoiceState 3
         self.add('state_servicerating_question3', function(name) {
-            //var q_id = '3';
+            var q_id = '3';
             var q_text_en = $("How long did you wait to be helped at the clinic?");
 
             return new ChoiceState(name, {
@@ -710,13 +722,19 @@ go.app = function() {
                     new Choice('more-than-4-hours', $('More than 4 hours')),
                     new Choice('all-day', $('All day'))
                 ],
-                next: 'state_servicerating_question4'
+                next: function(choice) {
+                    return go.utils_project
+                        .post_servicerating_feedback(self.im, q_id, q_text_en.args[0], choice.label, choice.value)
+                        .then(function() {
+                            return 'state_servicerating_question4';
+                        });
+                }
             });
         });
 
         // ChoiceState 4
         self.add('state_servicerating_question4', function(name) {
-            //var q_id = '4';
+            var q_id = '4';
             var q_text_en = $("Was the facility clean?");
 
             return new ChoiceState(name, {
@@ -727,13 +745,19 @@ go.app = function() {
                     new Choice('not-satisfied', $('Not Satisfied')),
                     new Choice('very-unsatisfied', $('Very unsatisfied'))
                 ],
-                next: 'state_servicerating_question5'
+                next: function(choice) {
+                    return go.utils_project
+                        .post_servicerating_feedback(self.im, q_id, q_text_en.args[0], choice.label, choice.value)
+                        .then(function() {
+                            return 'state_servicerating_question5';
+                        });
+                }
             });
         });
 
         // ChoiceState 5
         self.add('state_servicerating_question5', function(name) {
-            //var q_id = '5';
+            var q_id = '5';
             var q_text_en = $("Did you feel that your privacy was respected by the staff?");
 
             return new ChoiceState(name, {
@@ -744,13 +768,20 @@ go.app = function() {
                     new Choice('not-satisfied', $('Not Satisfied')),
                     new Choice('very-unsatisfied', $('Very unsatisfied'))
                 ],
-                next: 'state_end_servicerating'
+                next: function(choice) {
+                    return go.utils_project
+                        .post_servicerating_feedback(self.im, q_id, q_text_en.args[0], choice.label, choice.value)
+                        .then(function() {
+                            return 'state_end_servicerating';
+                        });
+                }
             });
         });
 
         // EndState 6
         self.add('state_end_servicerating', function(name) {
-            // set servicerating_unanswered flag to false...
+            // sets servicerating_unanswered to false indicating completed servicerating feedback
+            self.im.user.set_answer('servicerating_unanswered', false);
             return new EndState(name, {
                 text: $("Thank you for rating the FamilyConnect service."),
                 next: 'state_start'

--- a/src/ussd_public.js
+++ b/src/ussd_public.js
@@ -661,9 +661,9 @@ go.app = function() {
             });
         });
 
-    // REGISTRATION STATES
+    // SERVICERATING STATES
 
-        // ChoiceState
+        // ChoiceState 1
         self.add('state_servicerating_question1', function(name) {
             //var q_id = '1';
             var q_text_en = $("Welcome. When you signed up, were staff at the facility friendly & helpful?");
@@ -680,7 +680,7 @@ go.app = function() {
             });
         });
 
-        // ChoiceState
+        // ChoiceState 2
         self.add('state_servicerating_question2', function(name) {
             //var q_id = '2';
             var q_text_en = $("How do you feel about the time you had to wait at the facility?");
@@ -697,7 +697,7 @@ go.app = function() {
             });
         });
 
-        // ChoiceState
+        // ChoiceState 3
         self.add('state_servicerating_question3', function(name) {
             //var q_id = '3';
             var q_text_en = $("How long did you wait to be helped at the clinic?");
@@ -714,7 +714,7 @@ go.app = function() {
             });
         });
 
-        // ChoiceState
+        // ChoiceState 4
         self.add('state_servicerating_question4', function(name) {
             //var q_id = '4';
             var q_text_en = $("Was the facility clean?");
@@ -731,7 +731,7 @@ go.app = function() {
             });
         });
 
-        // ChoiceState
+        // ChoiceState 5
         self.add('state_servicerating_question5', function(name) {
             //var q_id = '5';
             var q_text_en = $("Did you feel that your privacy was respected by the staff?");
@@ -748,7 +748,7 @@ go.app = function() {
             });
         });
 
-        // EndState
+        // EndState 6
         self.add('state_end_servicerating', function(name) {
             // set servicerating_unanswered flag to false...
             return new EndState(name, {

--- a/src/ussd_public.js
+++ b/src/ussd_public.js
@@ -162,8 +162,10 @@ go.app = function() {
 
                         return go.utils_project
                             .check_servicerating_status({'msisdn': msisdn}, self.im)
-                            .then(function(servicerating_unanswered) {
-                                return servicerating_unanswered
+                            .then(function(servicerating_status) {
+                                self.im.user.set_answer('invite_uuid', servicerating_status.invite_uuid);
+                                self.im.user.set_answer('servicerating_unanswered', servicerating_status.unanswered);
+                                return self.im.user.answers.servicerating_unanswered
                                         ? self.states.create('state_servicerating_question1')
                                         : self.states.create('state_permission');
                             });
@@ -665,7 +667,7 @@ go.app = function() {
 
         // ChoiceState 1
         self.add('state_servicerating_question1', function(name) {
-            var q_id = '1';
+            var q_id = 1;
             var q_text_en = $("Welcome. When you signed up, were staff at the facility friendly & helpful?");
 
             return new ChoiceState(name, {
@@ -678,7 +680,7 @@ go.app = function() {
                 ],
                 next: function(choice) {
                     return go.utils_project
-                        .post_servicerating_feedback(self.im, q_id, q_text_en.args[0], choice.label, choice.value)
+                        .post_servicerating_feedback(self.im, q_id, q_text_en.args[0], choice.label, choice.value, 1, self.im.user.answers.invite_uuid)
                         .then(function() {
                             return 'state_servicerating_question2';
                         });
@@ -688,7 +690,7 @@ go.app = function() {
 
         // ChoiceState 2
         self.add('state_servicerating_question2', function(name) {
-            var q_id = '2';
+            var q_id = 2;
             var q_text_en = $("How do you feel about the time you had to wait at the facility?");
 
             return new ChoiceState(name, {
@@ -701,7 +703,7 @@ go.app = function() {
                 ],
                 next: function(choice) {
                     return go.utils_project
-                        .post_servicerating_feedback(self.im, q_id, q_text_en.args[0], choice.label, choice.value)
+                        .post_servicerating_feedback(self.im, q_id, q_text_en.args[0], choice.label, choice.value, 1, self.im.user.answers.invite_uuid)
                         .then(function() {
                             return 'state_servicerating_question3';
                         });
@@ -711,7 +713,7 @@ go.app = function() {
 
         // ChoiceState 3
         self.add('state_servicerating_question3', function(name) {
-            var q_id = '3';
+            var q_id = 3;
             var q_text_en = $("How long did you wait to be helped at the clinic?");
 
             return new ChoiceState(name, {
@@ -724,7 +726,7 @@ go.app = function() {
                 ],
                 next: function(choice) {
                     return go.utils_project
-                        .post_servicerating_feedback(self.im, q_id, q_text_en.args[0], choice.label, choice.value)
+                        .post_servicerating_feedback(self.im, q_id, q_text_en.args[0], choice.label, choice.value, 1, self.im.user.answers.invite_uuid)
                         .then(function() {
                             return 'state_servicerating_question4';
                         });
@@ -734,7 +736,7 @@ go.app = function() {
 
         // ChoiceState 4
         self.add('state_servicerating_question4', function(name) {
-            var q_id = '4';
+            var q_id = 4;
             var q_text_en = $("Was the facility clean?");
 
             return new ChoiceState(name, {
@@ -747,7 +749,7 @@ go.app = function() {
                 ],
                 next: function(choice) {
                     return go.utils_project
-                        .post_servicerating_feedback(self.im, q_id, q_text_en.args[0], choice.label, choice.value)
+                        .post_servicerating_feedback(self.im, q_id, q_text_en.args[0], choice.label, choice.value, 1, self.im.user.answers.invite_uuid)
                         .then(function() {
                             return 'state_servicerating_question5';
                         });
@@ -757,7 +759,7 @@ go.app = function() {
 
         // ChoiceState 5
         self.add('state_servicerating_question5', function(name) {
-            var q_id = '5';
+            var q_id = 5;
             var q_text_en = $("Did you feel that your privacy was respected by the staff?");
 
             return new ChoiceState(name, {
@@ -770,7 +772,7 @@ go.app = function() {
                 ],
                 next: function(choice) {
                     return go.utils_project
-                        .post_servicerating_feedback(self.im, q_id, q_text_en.args[0], choice.label, choice.value)
+                        .post_servicerating_feedback(self.im, q_id, q_text_en.args[0], choice.label, choice.value, 1, self.im.user.answers.invite_uuid)
                         .then(function() {
                             return 'state_end_servicerating';
                         });

--- a/src/ussd_public.js
+++ b/src/ussd_public.js
@@ -158,10 +158,10 @@ go.app = function() {
                         }
 
                         return go.utils_project
-                            .get_servicerating_status(user.id, self.im)
+                            .check_servicerating_status(user.id, self.im)
                             .then(function(status_data) {
-                                self.im.user.set_answer('invite_uuid', status_data.details.id);
-                                if (!status_data.details.expired && !status_data.details.completed) {
+                                if (status_data.details.id) {
+                                    self.im.user.set_answer('invite_uuid', status_data.details.id);
                                     return self.states.create('state_servicerating_question1');
                                 }
                                 else {

--- a/src/ussd_public.js
+++ b/src/ussd_public.js
@@ -784,9 +784,7 @@ go.app = function() {
             return go.utils_project
                 .set_servicerating_status_completed(self.im)
                 .then(function(response) {
-                    if (response.code === 200) {  // patch successful
-                        return self.states.create('state_end_servicerating');
-                    }
+                    return self.states.create('state_end_servicerating');
                 });
         });
 

--- a/src/ussd_public.js
+++ b/src/ussd_public.js
@@ -157,16 +157,11 @@ go.app = function() {
                             self.im.user.set_answer('mother_id', user.details.mother_id);
                         }
 
-                        //var msisdn = go.utils.normalize_msisdn(
-                        //    self.im.user.addr, self.im.config.country_code);
-
                         return go.utils_project
-                            .check_servicerating_status(user.id, self.im)
+                            .get_servicerating_status(user.id, self.im)
                             .then(function(status_data) {
-                                self.im.user.set_answer('invite_uuid', status_data.id);
-                                console.log("ussd_public.js->state_start UUID: "+status_data.id/*status_data.details.id*/);
-                                console.log("ussd_public.js->state_start CHECK: "+status_data.expired+" "+status_data.completed);
-                                if (!status_data.expired && !status_data.completed) {
+                                self.im.user.set_answer('invite_uuid', status_data.details.id);
+                                if (!status_data.details.expired && !status_data.details.completed) {
                                     return self.states.create('state_servicerating_question1');
                                 }
                                 else {

--- a/src/ussd_public.js
+++ b/src/ussd_public.js
@@ -160,8 +160,8 @@ go.app = function() {
                         return go.utils_project
                             .check_servicerating_status(user.id, self.im)
                             .then(function(status_data) {
-                                if (status_data.details.id) {
-                                    self.im.user.set_answer('invite_uuid', status_data.details.id);
+                                if (status_data.results.id) {
+                                    self.im.user.set_answer('invite_uuid', status_data.results.id);
                                     return self.states.create('state_servicerating_question1');
                                 }
                                 else {

--- a/src/ussd_public.js
+++ b/src/ussd_public.js
@@ -773,16 +773,26 @@ go.app = function() {
                     return go.utils_project
                         .post_servicerating_feedback(self.im, q_id, q_text_en.args[0], choice.label, choice.value, 1, self.im.user.answers.invite_uuid)
                         .then(function() {
-                            return 'state_end_servicerating';
+                            return 'state_set_servicerating_completed';
                         });
                 }
             });
         });
 
+        // Interstitial
+        self.add('state_set_servicerating_completed', function(name) {
+            return go.utils_project
+                .set_servicerating_status_completed(self.im)
+                .then(function(response) {
+                    if (response.code === 200) {  // patch successful
+                        return self.states.create('state_end_servicerating');
+                    }
+                });
+        });
+
         // EndState 6
         self.add('state_end_servicerating', function(name) {
-            // sets servicerating_unanswered to false indicating completed servicerating feedback
-            self.im.user.set_answer('servicerating_unanswered', false);
+            // sets service rating status as completed
             return new EndState(name, {
                 text: $("Thank you for rating the FamilyConnect service."),
                 next: 'state_start'

--- a/src/ussd_public.js
+++ b/src/ussd_public.js
@@ -157,17 +157,21 @@ go.app = function() {
                             self.im.user.set_answer('mother_id', user.details.mother_id);
                         }
 
-                        var msisdn = go.utils.normalize_msisdn(
-                            self.im.user.addr, self.im.config.country_code);
+                        //var msisdn = go.utils.normalize_msisdn(
+                        //    self.im.user.addr, self.im.config.country_code);
 
                         return go.utils_project
-                            .check_servicerating_status({'msisdn': msisdn}, self.im)
-                            .then(function(servicerating_status) {
-                                self.im.user.set_answer('invite_uuid', servicerating_status.invite_uuid);
-                                self.im.user.set_answer('servicerating_unanswered', servicerating_status.unanswered);
-                                return self.im.user.answers.servicerating_unanswered
-                                        ? self.states.create('state_servicerating_question1')
-                                        : self.states.create('state_permission');
+                            .check_servicerating_status(user.id, self.im)
+                            .then(function(status_data) {
+                                self.im.user.set_answer('invite_uuid', status_data.id);
+                                console.log("ussd_public.js->state_start UUID: "+status_data.id/*status_data.details.id*/);
+                                console.log("ussd_public.js->state_start CHECK: "+status_data.expired+" "+status_data.completed);
+                                if (!status_data.expired && !status_data.completed) {
+                                    return self.states.create('state_servicerating_question1');
+                                }
+                                else {
+                                    return self.states.create('state_permission');
+                                }
                             });
                     } else {
                         self.im.user.set_answer('role', 'guest');

--- a/src/utils_project.js
+++ b/src/utils_project.js
@@ -380,8 +380,8 @@ go.utils_project = {
     check_servicerating_status: function(identity, im) {
         var params = {
             "identity": identity,
-            "completed": false,
-            "expired": false
+            "completed": 'False',
+            "expired": 'False'
         };
         return go.utils
             .service_api_call("service_rating", "get", params, null, "invite/", im)

--- a/src/utils_project.js
+++ b/src/utils_project.js
@@ -380,14 +380,19 @@ go.utils_project = {
         return go.utils
             .get_identity_by_address(address, im)
             .then(function(identity) {
-                return identity.details.servicerating_unanswered;
+                return {
+                    unanswered: identity.details.servicerating_unanswered,
+                    invite_uuid: identity.details.invite,
+                };
             });
     },
 
     // saves servicerating info
-    post_servicerating_feedback: function(im, q_id, q_text, answer_text, answer_value) {
+    post_servicerating_feedback: function(im, q_id, q_text, answer_text, answer_value, version_number, invite_uuid) {
         var payload = {
             "identity_id": im.user.answers.user_id,
+            "invite": invite_uuid,
+            "version": version_number,
             "question_id": q_id,
             "question_text": q_text,
             "answer_text": answer_text,
@@ -395,7 +400,7 @@ go.utils_project = {
         };
 
         return go.utils
-            .service_api_call("servicerating", "post", null, payload, "servicerating/", im)
+            .service_api_call("rating", "post", null, payload, "rating/", im)
             .then(function(response) {
                 return response;
             });

--- a/src/utils_project.js
+++ b/src/utils_project.js
@@ -384,19 +384,24 @@ go.utils_project = {
             });
     },
 
-    // saves service rating info and sets servicerating_unanswered flag
-    save_servicerating_info: function(identity_id, im) {
+    // saves servicerating info
+    post_servicerating_feedback: function(im, q_id, q_text, answer_text, answer_value) {
+        var payload = {
+            "identity_id": im.user.answers.user_id,
+            "question_id": q_id,
+            "question_text": q_text,
+            "answer_text": answer_text,
+            "answer_value": answer_value
+        };
+
         return go.utils
-            .get_identity(identity_id, im)
-            .then(function(identity) {
-                identity.details.question1 = im.user.answers.state_servicerating_question1;
-                identity.details.question2 = im.user.answers.state_servicerating_question2;
-                identity.details.question3 = im.user.answers.state_servicerating_question3;
-                identity.details.question4 = im.user.answers.state_servicerating_question4;
-                identity.details.question5 = im.user.answers.state_servicerating_question5;
-                identity.details.servicerating_unanswered = false;
+            .service_api_call("servicerating", "post", null, payload, "servicerating/", im)
+            .then(function(response) {
+                return response;
             });
     },
+
+
 
     "commas": "commas"
 };

--- a/src/utils_project.js
+++ b/src/utils_project.js
@@ -375,15 +375,17 @@ go.utils_project = {
 
     // SERVICERATING HELPERS
 
-    // returns true if service rating unanswered
-    check_servicerating_status: function(address, im) {
+    // ...
+    check_servicerating_status: function(identity, im) {
+        var endpoint = 'invite/';
         return go.utils
-            .get_identity_by_address(address, im)
-            .then(function(identity) {
-                return {
-                    unanswered: identity.details.servicerating_unanswered,
-                    invite_uuid: identity.details.invite,
-                };
+            .service_api_call("service_rating", "get", null, null, endpoint, im)
+            .then(function(json_get_response) {
+                /*console.log("***");
+                util = require("util");
+                var data = util.inspect(json_get_response);
+                console.log(data);*/
+                return json_get_response.data;
             });
     },
 

--- a/src/utils_project.js
+++ b/src/utils_project.js
@@ -386,9 +386,6 @@ go.utils_project = {
         return go.utils
             .service_api_call("service_rating", "get", params, null, "invite/", im)
             .then(function(json_get_response) {
-                /*util = require('util');
-                var dataObj = util.inspect(json_get_response.data);
-                console.log(dataObj);*/
                 return json_get_response.data;
             });
     },

--- a/src/utils_project.js
+++ b/src/utils_project.js
@@ -375,12 +375,20 @@ go.utils_project = {
 
     // SERVICERATING HELPERS
 
-    // get service rating status / invite
-    get_servicerating_status: function(identity, im) {
-        var endpoint = 'invite/'+identity+'/';
+    // check service rating status
+
+    check_servicerating_status: function(identity, im) {
+        var params = {
+            "identity": identity,
+            "completed": false,
+            "expired": false
+        };
         return go.utils
-            .service_api_call("service_rating", "get", null, null, endpoint, im)
+            .service_api_call("service_rating", "get", params, null, "invite/", im)
             .then(function(json_get_response) {
+                /*util = require('util');
+                var dataObj = util.inspect(json_get_response.data);
+                console.log(dataObj);*/
                 return json_get_response.data;
             });
     },

--- a/src/utils_project.js
+++ b/src/utils_project.js
@@ -390,7 +390,7 @@ go.utils_project = {
     // saves servicerating info
     post_servicerating_feedback: function(im, q_id, q_text, answer_text, answer_value, version_number, invite_uuid) {
         var payload = {
-            "identity_id": im.user.answers.user_id,
+            "identity": im.user.answers.user_id,
             "invite": invite_uuid,
             "version": version_number,
             "question_id": q_id,

--- a/src/utils_project.js
+++ b/src/utils_project.js
@@ -375,8 +375,7 @@ go.utils_project = {
 
     // SERVICERATING HELPERS
 
-    // check service rating status
-
+    // check for service rating status not completed yet
     check_servicerating_status: function(identity, im) {
         var params = {
             "identity": identity,
@@ -409,6 +408,19 @@ go.utils_project = {
             });
     },
 
+    // sets service rating 'completed' to true
+    set_servicerating_status_completed: function(im) {
+        var endpoint = "invite/"+im.user.answers.invite_uuid+"/";
+        var payload = {
+            "completed": 'True'
+        };
+
+        return go.utils
+            .service_api_call("service_rating", "patch", null, payload, endpoint, im)
+            .then(function(response) {
+                return response;
+            });
+    },
 
 
     "commas": "commas"

--- a/src/utils_project.js
+++ b/src/utils_project.js
@@ -375,16 +375,12 @@ go.utils_project = {
 
     // SERVICERATING HELPERS
 
-    // ...
-    check_servicerating_status: function(identity, im) {
-        var endpoint = 'invite/';
+    // get service rating status / invite
+    get_servicerating_status: function(identity, im) {
+        var endpoint = 'invite/'+identity+'/';
         return go.utils
             .service_api_call("service_rating", "get", null, null, endpoint, im)
             .then(function(json_get_response) {
-                /*console.log("***");
-                util = require("util");
-                var data = util.inspect(json_get_response);
-                console.log(data);*/
                 return json_get_response.data;
             });
     },

--- a/src/utils_project.js
+++ b/src/utils_project.js
@@ -379,8 +379,8 @@ go.utils_project = {
     check_servicerating_status: function(identity, im) {
         var params = {
             "identity": identity,
-            "completed": 'False',
-            "expired": 'False'
+            "completed": "False",
+            "expired": "False"
         };
         return go.utils
             .service_api_call("service_rating", "get", params, null, "invite/", im)
@@ -412,7 +412,7 @@ go.utils_project = {
     set_servicerating_status_completed: function(im) {
         var endpoint = "invite/"+im.user.answers.invite_uuid+"/";
         var payload = {
-            "completed": 'True'
+            "completed": "True"
         };
 
         return go.utils

--- a/src/utils_project.js
+++ b/src/utils_project.js
@@ -400,7 +400,7 @@ go.utils_project = {
         };
 
         return go.utils
-            .service_api_call("rating", "post", null, payload, "rating/", im)
+            .service_api_call("service_rating", "post", null, payload, "service_rating/", im)
             .then(function(response) {
                 return response;
             });

--- a/src/utils_project.js
+++ b/src/utils_project.js
@@ -384,5 +384,19 @@ go.utils_project = {
             });
     },
 
+    // saves service rating info and sets servicerating_unanswered flag
+    save_servicerating_info: function(identity_id, im) {
+        return go.utils
+            .get_identity(identity_id, im)
+            .then(function(identity) {
+                identity.details.question1 = im.user.answers.state_servicerating_question1;
+                identity.details.question2 = im.user.answers.state_servicerating_question2;
+                identity.details.question3 = im.user.answers.state_servicerating_question3;
+                identity.details.question4 = im.user.answers.state_servicerating_question4;
+                identity.details.question5 = im.user.answers.state_servicerating_question5;
+                identity.details.servicerating_unanswered = false;
+            });
+    },
+
     "commas": "commas"
 };

--- a/src/utils_project.js
+++ b/src/utils_project.js
@@ -400,7 +400,7 @@ go.utils_project = {
         };
 
         return go.utils
-            .service_api_call("service_rating", "post", null, payload, "service_rating/", im)
+            .service_api_call("service_rating", "post", null, payload, "rating/", im)
             .then(function(response) {
                 return response;
             });

--- a/test/fixtures_public.js
+++ b/test/fixtures_public.js
@@ -1450,7 +1450,7 @@ return [
                 'Authorization': ['Token test_key'],
                 'Content-Type': ['application/json']
             },
-            'url': 'http://localhost:8006/api/v1/invite/',
+            'url': 'http://localhost:8006/api/v1/invite/3f7c8851-5204-43f7-af7f-000000000222/',
         },
         'response': {
             "code": 200,
@@ -1458,11 +1458,11 @@ return [
                 "count": 1,
                 "next": null,
                 "previous": null,
-                "details": [{
+                "details": {
                     "updated_at": "2016-04-04T17:06:08.411867Z",
                     "created_at": "2016-04-04T17:06:08.411843Z",
                     "version": 1,
-                    "expired": false,
+                    "expired": true,
                     "id": "1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b",
                     "identity": "3f7c8851-5204-43f7-af7f-000000000222",
                     "completed": false,
@@ -1473,7 +1473,7 @@ return [
                         "to_addr": "+27123",
                         "metadata": {}
                     }
-                }]
+                }
             }
         }
     },
@@ -1483,16 +1483,14 @@ return [
         'repeatable': true,
         'request': {
             'method': 'GET',
-            'params': {
-                "expired": false,
-                "completed": false,
-                "identity": "3f7c8851-5204-43f7-af7f-000000000777"
+            'param': {
+                "user_uuid": "3f7c8851-5204-43f7-af7f-000000000777"
             },
             'headers': {
                 'Authorization': ['Token test_key'],
                 'Content-Type': ['application/json']
             },
-            'url': 'http://localhost:8006/api/v1/invite/',
+            'url': 'http://localhost:8006/api/v1/invite/3f7c8851-5204-43f7-af7f-000000000777/',
         },
         'response': {
             "code": 200,
@@ -1500,11 +1498,12 @@ return [
                 "count": 1,
                 "next": null,
                 "previous": null,
-                "results": [{
-                    "url": "http://localhost:8006/api/v1/invite/1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b",
-                    "id": "1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b",
+                "details": {
+                    "updated_at": "2016-04-04T17:06:08.411867Z",
+                    "created_at": "2016-04-04T17:06:08.411843Z",
                     "version": 1,
                     "expired": false,
+                    "id": "1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b",
                     "identity": "3f7c8851-5204-43f7-af7f-000000000777",
                     "completed": false,
                     "invited": true,
@@ -1513,10 +1512,8 @@ return [
                         "content": "Please dial *120*1234# and rate our service",
                         "to_addr": "+27123",
                         "metadata": {}
-                    },
-                    "updated_at": "2016-04-04T17:06:08.411867Z",
-                    "created_at": "2016-04-04T17:06:08.411843Z"
-                }]
+                    }
+                }
             }
         }
     },

--- a/test/fixtures_public.js
+++ b/test/fixtures_public.js
@@ -1298,7 +1298,8 @@ return [
                         "role": "mother",
                         "preferred_msg_type": "sms",
                         "preferred_language": "eng_UG",
-                        "servicerating_unanswered": true
+                        "servicerating_unanswered": true,
+                        "invite": "1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b",
                     },
                     "created_at": "2015-07-10T06:13:29.693272Z",
                     "updated_at": "2015-07-10T06:13:29.693298Z"
@@ -1315,10 +1316,12 @@ return [
                 'Authorization': ['Token test_key'],
                 'Content-Type': ['application/json']
             },
-            'url': 'http://localhost:8006/api/v1/servicerating/',
+            'url': 'http://localhost:8006/api/v1/rating/',
             'data': {
                 "identity_id": "3f7c8851-5204-43f7-af7f-000000000777",
-                "question_id": '1',
+                "invite": "1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b",
+                "version": 1,
+                "question_id": 1,
                 "question_text": "Welcome. When you signed up, were staff at the facility friendly & helpful?",
                 "answer_text": "Satisfied",
                 "answer_value": "satisfied"
@@ -1340,10 +1343,12 @@ return [
                 'Authorization': ['Token test_key'],
                 'Content-Type': ['application/json']
             },
-            'url': 'http://localhost:8006/api/v1/servicerating/',
+            'url': 'http://localhost:8006/api/v1/rating/',
             'data': {
                 "identity_id": "3f7c8851-5204-43f7-af7f-000000000777",
-                "question_id": '2',
+                "invite": "1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b",
+                "version": 1,
+                "question_id": 2,
                 "question_text": "How do you feel about the time you had to wait at the facility?",
                 "answer_text": "Satisfied",
                 "answer_value": "satisfied"
@@ -1365,10 +1370,12 @@ return [
                 'Authorization': ['Token test_key'],
                 'Content-Type': ['application/json']
             },
-            'url': 'http://localhost:8006/api/v1/servicerating/',
+            'url': 'http://localhost:8006/api/v1/rating/',
             'data': {
                 "identity_id": "3f7c8851-5204-43f7-af7f-000000000777",
-                "question_id": '3',
+                "invite": "1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b",
+                "version": 1,
+                "question_id": 3,
                 "question_text": "How long did you wait to be helped at the clinic?",
                 "answer_text": "More than 4 hours",
                 "answer_value": "more-than-4-hours"
@@ -1390,10 +1397,12 @@ return [
                 'Authorization': ['Token test_key'],
                 'Content-Type': ['application/json']
             },
-            'url': 'http://localhost:8006/api/v1/servicerating/',
+            'url': 'http://localhost:8006/api/v1/rating/',
             'data': {
                 "identity_id": "3f7c8851-5204-43f7-af7f-000000000777",
-                "question_id": '4',
+                "invite": "1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b",
+                "version": 1,
+                "question_id": 4,
                 "question_text": "Was the facility clean?",
                 "answer_text": "Very unsatisfied",
                 "answer_value": "very-unsatisfied"
@@ -1415,10 +1424,12 @@ return [
                 'Authorization': ['Token test_key'],
                 'Content-Type': ['application/json']
             },
-            'url': 'http://localhost:8006/api/v1/servicerating/',
+            'url': 'http://localhost:8006/api/v1/rating/',
             'data': {
                 "identity_id": "3f7c8851-5204-43f7-af7f-000000000777",
-                "question_id": '5',
+                "invite": "1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b",
+                "version": 1,
+                "question_id": 5,
                 "question_text": "Did you feel that your privacy was respected by the staff?",
                 "answer_text": "Very Satisfied",
                 "answer_value": "very-satisfied"

--- a/test/fixtures_public.js
+++ b/test/fixtures_public.js
@@ -1307,5 +1307,130 @@ return [
         }
     },
 
+    // 40: save servicerating question 1 feedback - 0007777
+    {
+        'request': {
+            'method': 'POST',
+            'headers': {
+                'Authorization': ['Token test_key'],
+                'Content-Type': ['application/json']
+            },
+            'url': 'http://localhost:8006/api/v1/servicerating/',
+            'data': {
+                "identity_id": "3f7c8851-5204-43f7-af7f-000000000777",
+                "question_id": '1',
+                "question_text": "Welcome. When you signed up, were staff at the facility friendly & helpful?",
+                "answer_text": "Satisfied",
+                "answer_value": "satisfied"
+            }
+        },
+        'response': {
+            'code': 201,
+            'data': {
+                'id': 1
+            }
+        }
+    },
+
+    // 41: save servicerating question 2 feedback - 0007777
+    {
+        'request': {
+            'method': 'POST',
+            'headers': {
+                'Authorization': ['Token test_key'],
+                'Content-Type': ['application/json']
+            },
+            'url': 'http://localhost:8006/api/v1/servicerating/',
+            'data': {
+                "identity_id": "3f7c8851-5204-43f7-af7f-000000000777",
+                "question_id": '2',
+                "question_text": "How do you feel about the time you had to wait at the facility?",
+                "answer_text": "Satisfied",
+                "answer_value": "satisfied"
+            }
+        },
+        'response': {
+            'code': 201,
+            'data': {
+                'id': 1
+            }
+        }
+    },
+
+    // 42: save servicerating question 3 feedback - 0007777
+    {
+        'request': {
+            'method': 'POST',
+            'headers': {
+                'Authorization': ['Token test_key'],
+                'Content-Type': ['application/json']
+            },
+            'url': 'http://localhost:8006/api/v1/servicerating/',
+            'data': {
+                "identity_id": "3f7c8851-5204-43f7-af7f-000000000777",
+                "question_id": '3',
+                "question_text": "How long did you wait to be helped at the clinic?",
+                "answer_text": "More than 4 hours",
+                "answer_value": "more-than-4-hours"
+            }
+        },
+        'response': {
+            'code': 201,
+            'data': {
+                'id': 1
+            }
+        }
+    },
+
+    // 43: save servicerating question 4 feedback - 0007777
+    {
+        'request': {
+            'method': 'POST',
+            'headers': {
+                'Authorization': ['Token test_key'],
+                'Content-Type': ['application/json']
+            },
+            'url': 'http://localhost:8006/api/v1/servicerating/',
+            'data': {
+                "identity_id": "3f7c8851-5204-43f7-af7f-000000000777",
+                "question_id": '4',
+                "question_text": "Was the facility clean?",
+                "answer_text": "Very unsatisfied",
+                "answer_value": "very-unsatisfied"
+            }
+        },
+        'response': {
+            'code': 201,
+            'data': {
+                'id': 1
+            }
+        }
+    },
+
+    // 44: save servicerating question 5 feedback - 0007777
+    {
+        'request': {
+            'method': 'POST',
+            'headers': {
+                'Authorization': ['Token test_key'],
+                'Content-Type': ['application/json']
+            },
+            'url': 'http://localhost:8006/api/v1/servicerating/',
+            'data': {
+                "identity_id": "3f7c8851-5204-43f7-af7f-000000000777",
+                "question_id": '5',
+                "question_text": "Did you feel that your privacy was respected by the staff?",
+                "answer_text": "Very Satisfied",
+                "answer_value": "very-satisfied"
+            }
+        },
+        'response': {
+            'code': 201,
+            'data': {
+                'id': 1
+            }
+        }
+    }
+
 ];
 };

--- a/test/fixtures_public.js
+++ b/test/fixtures_public.js
@@ -1264,7 +1264,7 @@ return [
         }
     },
 
-    // 39: get identity 0720000222 by msisdn
+    // 39: get identity 0720000777 by msisdn
     {
         'repeatable': true,
         'request': {
@@ -1298,8 +1298,6 @@ return [
                         "role": "mother",
                         "preferred_msg_type": "sms",
                         "preferred_language": "eng_UG",
-                        "servicerating_unanswered": true,
-                        "invite": "1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b",
                     },
                     "created_at": "2015-07-10T06:13:29.693272Z",
                     "updated_at": "2015-07-10T06:13:29.693298Z"
@@ -1441,7 +1439,87 @@ return [
                 'id': 1
             }
         }
-    }
+    },
+
+    // 45: get identity 3f7c8851-5204-43f7-af7f-000000000222 service rating
+    {
+        'repeatable': true,
+        'request': {
+            'method': 'GET',
+            'headers': {
+                'Authorization': ['Token test_key'],
+                'Content-Type': ['application/json']
+            },
+            'url': 'http://localhost:8006/api/v1/invite/',
+        },
+        'response': {
+            "code": 200,
+            "data": {
+                "count": 1,
+                "next": null,
+                "previous": null,
+                "details": [{
+                    "updated_at": "2016-04-04T17:06:08.411867Z",
+                    "created_at": "2016-04-04T17:06:08.411843Z",
+                    "version": 1,
+                    "expired": false,
+                    "id": "1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b",
+                    "identity": "3f7c8851-5204-43f7-af7f-000000000222",
+                    "completed": false,
+                    "invited": false,
+                    "expires_at": null,
+                    "invite": {
+                        "content": "Please dial *120*1234# and rate our service",
+                        "to_addr": "+27123",
+                        "metadata": {}
+                    }
+                }]
+            }
+        }
+    },
+
+    // 46: get identity 3f7c8851-5204-43f7-af7f-000000000777 service rating
+    {
+        'repeatable': true,
+        'request': {
+            'method': 'GET',
+            'params': {
+                "expired": false,
+                "completed": false,
+                "identity": "3f7c8851-5204-43f7-af7f-000000000777"
+            },
+            'headers': {
+                'Authorization': ['Token test_key'],
+                'Content-Type': ['application/json']
+            },
+            'url': 'http://localhost:8006/api/v1/invite/',
+        },
+        'response': {
+            "code": 200,
+            "data": {
+                "count": 1,
+                "next": null,
+                "previous": null,
+                "results": [{
+                    "url": "http://localhost:8006/api/v1/invite/1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b",
+                    "id": "1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b",
+                    "version": 1,
+                    "expired": false,
+                    "identity": "3f7c8851-5204-43f7-af7f-000000000777",
+                    "completed": false,
+                    "invited": true,
+                    "expires_at": null,
+                    "invite": {
+                        "content": "Please dial *120*1234# and rate our service",
+                        "to_addr": "+27123",
+                        "metadata": {}
+                    },
+                    "updated_at": "2016-04-04T17:06:08.411867Z",
+                    "created_at": "2016-04-04T17:06:08.411843Z"
+                }]
+            }
+        }
+    },
 
 ];
 };

--- a/test/fixtures_public.js
+++ b/test/fixtures_public.js
@@ -1318,7 +1318,7 @@ return [
             },
             'url': 'http://localhost:8006/api/v1/service_rating/',
             'data': {
-                "identity_id": "3f7c8851-5204-43f7-af7f-000000000777",
+                "identity": "3f7c8851-5204-43f7-af7f-000000000777",
                 "invite": "1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b",
                 "version": 1,
                 "question_id": 1,
@@ -1345,7 +1345,7 @@ return [
             },
             'url': 'http://localhost:8006/api/v1/service_rating/',
             'data': {
-                "identity_id": "3f7c8851-5204-43f7-af7f-000000000777",
+                "identity": "3f7c8851-5204-43f7-af7f-000000000777",
                 "invite": "1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b",
                 "version": 1,
                 "question_id": 2,
@@ -1372,7 +1372,7 @@ return [
             },
             'url': 'http://localhost:8006/api/v1/service_rating/',
             'data': {
-                "identity_id": "3f7c8851-5204-43f7-af7f-000000000777",
+                "identity": "3f7c8851-5204-43f7-af7f-000000000777",
                 "invite": "1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b",
                 "version": 1,
                 "question_id": 3,
@@ -1399,7 +1399,7 @@ return [
             },
             'url': 'http://localhost:8006/api/v1/service_rating/',
             'data': {
-                "identity_id": "3f7c8851-5204-43f7-af7f-000000000777",
+                "identity": "3f7c8851-5204-43f7-af7f-000000000777",
                 "invite": "1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b",
                 "version": 1,
                 "question_id": 4,
@@ -1426,7 +1426,7 @@ return [
             },
             'url': 'http://localhost:8006/api/v1/service_rating/',
             'data': {
-                "identity_id": "3f7c8851-5204-43f7-af7f-000000000777",
+                "identity": "3f7c8851-5204-43f7-af7f-000000000777",
                 "invite": "1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b",
                 "version": 1,
                 "question_id": 5,

--- a/test/fixtures_public.js
+++ b/test/fixtures_public.js
@@ -1500,5 +1500,25 @@ return [
         }
     },
 
+    // 47: patch service rating invite 1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b
+    {
+        'request': {
+            'method': 'PATCH',
+            'headers': {
+                'Authorization': ['Token test_key']
+            },
+            'url': 'http://localhost:8006/api/v1/invite/1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b/',
+            "data": {
+                "completed": 'True'
+            }
+        },
+        'response': {
+            "code": 200,
+            "data": {
+                "success": "true"
+            }
+        }
+    },
+
 ];
 };

--- a/test/fixtures_public.js
+++ b/test/fixtures_public.js
@@ -1443,18 +1443,19 @@ return [
 
     // 45: get identity 3f7c8851-5204-43f7-af7f-000000000222 service rating status
     {
+        'repeatable': true,
         'request': {
             'method': 'GET',
             'params': {
-                //"identity": "3f7c8851-5204-43f7-af7f-000000000222",
-                "completed": false,
-                "expired": false
+                "identity": "3f7c8851-5204-43f7-af7f-000000000222",
+                "completed": 'False',
+                "expired": 'False'
             },
             'headers': {
                 'Authorization': ['Token test_key'],
                 'Content-Type': ['application/json']
             },
-            'url': 'http://localhost:8006/api/v1/invite/?3f7c8851-5204-43f7-af7f-000000000222',
+            'url': 'http://localhost:8006/api/v1/invite/',
         },
         'response': {
             "code": 200,
@@ -1471,10 +1472,10 @@ return [
     {
         'request': {
             'method': 'GET',
-            'param': {
+            'params': {
                 "identity": "3f7c8851-5204-43f7-af7f-000000000777",
-                "completed": false,
-                "expired": false
+                "completed": 'False',
+                "expired": 'False'
             },
             'headers': {
                 'Authorization': ['Token test_key'],
@@ -1488,7 +1489,7 @@ return [
                 "count": 1,
                 "next": null,
                 "previous": null,
-                "details": {
+                "results": {
                     "updated_at": "2016-04-04T17:06:08.411867Z",
                     "created_at": "2016-04-04T17:06:08.411843Z",
                     "version": 1,

--- a/test/fixtures_public.js
+++ b/test/fixtures_public.js
@@ -1489,13 +1489,13 @@ return [
                 "count": 1,
                 "next": null,
                 "previous": null,
-                "results": {
+                "results": [{
                     "updated_at": "2016-04-04T17:06:08.411867Z",
                     "created_at": "2016-04-04T17:06:08.411843Z",
                     "version": 1,
                     "id": "1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b",
                     "identity": "3f7c8851-5204-43f7-af7f-000000000777",
-                }
+                }]
             }
         }
     },

--- a/test/fixtures_public.js
+++ b/test/fixtures_public.js
@@ -1316,7 +1316,7 @@ return [
                 'Authorization': ['Token test_key'],
                 'Content-Type': ['application/json']
             },
-            'url': 'http://localhost:8006/api/v1/rating/',
+            'url': 'http://localhost:8006/api/v1/service_rating/',
             'data': {
                 "identity_id": "3f7c8851-5204-43f7-af7f-000000000777",
                 "invite": "1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b",
@@ -1343,7 +1343,7 @@ return [
                 'Authorization': ['Token test_key'],
                 'Content-Type': ['application/json']
             },
-            'url': 'http://localhost:8006/api/v1/rating/',
+            'url': 'http://localhost:8006/api/v1/service_rating/',
             'data': {
                 "identity_id": "3f7c8851-5204-43f7-af7f-000000000777",
                 "invite": "1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b",
@@ -1370,7 +1370,7 @@ return [
                 'Authorization': ['Token test_key'],
                 'Content-Type': ['application/json']
             },
-            'url': 'http://localhost:8006/api/v1/rating/',
+            'url': 'http://localhost:8006/api/v1/service_rating/',
             'data': {
                 "identity_id": "3f7c8851-5204-43f7-af7f-000000000777",
                 "invite": "1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b",
@@ -1397,7 +1397,7 @@ return [
                 'Authorization': ['Token test_key'],
                 'Content-Type': ['application/json']
             },
-            'url': 'http://localhost:8006/api/v1/rating/',
+            'url': 'http://localhost:8006/api/v1/service_rating/',
             'data': {
                 "identity_id": "3f7c8851-5204-43f7-af7f-000000000777",
                 "invite": "1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b",
@@ -1424,7 +1424,7 @@ return [
                 'Authorization': ['Token test_key'],
                 'Content-Type': ['application/json']
             },
-            'url': 'http://localhost:8006/api/v1/rating/',
+            'url': 'http://localhost:8006/api/v1/service_rating/',
             'data': {
                 "identity_id": "3f7c8851-5204-43f7-af7f-000000000777",
                 "invite": "1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b",

--- a/test/fixtures_public.js
+++ b/test/fixtures_public.js
@@ -1316,7 +1316,7 @@ return [
                 'Authorization': ['Token test_key'],
                 'Content-Type': ['application/json']
             },
-            'url': 'http://localhost:8006/api/v1/service_rating/',
+            'url': 'http://localhost:8006/api/v1/rating/',
             'data': {
                 "identity": "3f7c8851-5204-43f7-af7f-000000000777",
                 "invite": "1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b",
@@ -1343,7 +1343,7 @@ return [
                 'Authorization': ['Token test_key'],
                 'Content-Type': ['application/json']
             },
-            'url': 'http://localhost:8006/api/v1/service_rating/',
+            'url': 'http://localhost:8006/api/v1/rating/',
             'data': {
                 "identity": "3f7c8851-5204-43f7-af7f-000000000777",
                 "invite": "1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b",
@@ -1370,7 +1370,7 @@ return [
                 'Authorization': ['Token test_key'],
                 'Content-Type': ['application/json']
             },
-            'url': 'http://localhost:8006/api/v1/service_rating/',
+            'url': 'http://localhost:8006/api/v1/rating/',
             'data': {
                 "identity": "3f7c8851-5204-43f7-af7f-000000000777",
                 "invite": "1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b",
@@ -1397,7 +1397,7 @@ return [
                 'Authorization': ['Token test_key'],
                 'Content-Type': ['application/json']
             },
-            'url': 'http://localhost:8006/api/v1/service_rating/',
+            'url': 'http://localhost:8006/api/v1/rating/',
             'data': {
                 "identity": "3f7c8851-5204-43f7-af7f-000000000777",
                 "invite": "1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b",
@@ -1424,7 +1424,7 @@ return [
                 'Authorization': ['Token test_key'],
                 'Content-Type': ['application/json']
             },
-            'url': 'http://localhost:8006/api/v1/service_rating/',
+            'url': 'http://localhost:8006/api/v1/rating/',
             'data': {
                 "identity": "3f7c8851-5204-43f7-af7f-000000000777",
                 "invite": "1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b",

--- a/test/fixtures_public.js
+++ b/test/fixtures_public.js
@@ -1441,56 +1441,46 @@ return [
         }
     },
 
-    // 45: get identity 3f7c8851-5204-43f7-af7f-000000000222 service rating
+    // 45: get identity 3f7c8851-5204-43f7-af7f-000000000222 service rating status
     {
-        'repeatable': true,
         'request': {
             'method': 'GET',
+            'params': {
+                //"identity": "3f7c8851-5204-43f7-af7f-000000000222",
+                "completed": false,
+                "expired": false
+            },
             'headers': {
                 'Authorization': ['Token test_key'],
                 'Content-Type': ['application/json']
             },
-            'url': 'http://localhost:8006/api/v1/invite/3f7c8851-5204-43f7-af7f-000000000222/',
+            'url': 'http://localhost:8006/api/v1/invite/?3f7c8851-5204-43f7-af7f-000000000222',
         },
         'response': {
             "code": 200,
             "data": {
-                "count": 1,
+                "count": 0,
                 "next": null,
                 "previous": null,
-                "details": {
-                    "updated_at": "2016-04-04T17:06:08.411867Z",
-                    "created_at": "2016-04-04T17:06:08.411843Z",
-                    "version": 1,
-                    "expired": true,
-                    "id": "1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b",
-                    "identity": "3f7c8851-5204-43f7-af7f-000000000222",
-                    "completed": false,
-                    "invited": false,
-                    "expires_at": null,
-                    "invite": {
-                        "content": "Please dial *120*1234# and rate our service",
-                        "to_addr": "+27123",
-                        "metadata": {}
-                    }
-                }
+                "results": []
             }
         }
     },
 
-    // 46: get identity 3f7c8851-5204-43f7-af7f-000000000777 service rating
+    // 46: get identity 3f7c8851-5204-43f7-af7f-000000000777 service rating status
     {
-        'repeatable': true,
         'request': {
             'method': 'GET',
             'param': {
-                "user_uuid": "3f7c8851-5204-43f7-af7f-000000000777"
+                "identity": "3f7c8851-5204-43f7-af7f-000000000777",
+                "completed": false,
+                "expired": false
             },
             'headers': {
                 'Authorization': ['Token test_key'],
                 'Content-Type': ['application/json']
             },
-            'url': 'http://localhost:8006/api/v1/invite/3f7c8851-5204-43f7-af7f-000000000777/',
+            'url': 'http://localhost:8006/api/v1/invite/',
         },
         'response': {
             "code": 200,
@@ -1502,17 +1492,8 @@ return [
                     "updated_at": "2016-04-04T17:06:08.411867Z",
                     "created_at": "2016-04-04T17:06:08.411843Z",
                     "version": 1,
-                    "expired": false,
                     "id": "1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b",
                     "identity": "3f7c8851-5204-43f7-af7f-000000000777",
-                    "completed": false,
-                    "invited": true,
-                    "expires_at": null,
-                    "invite": {
-                        "content": "Please dial *120*1234# and rate our service",
-                        "to_addr": "+27123",
-                        "metadata": {}
-                    }
                 }
             }
         }

--- a/test/ussd_public.test.js
+++ b/test/ussd_public.test.js
@@ -32,8 +32,8 @@ describe("familyconnect health worker app", function() {
                             api_token: 'test_token_subscriptions',
                             url: "http://localhost:8005/api/v1/"
                         },
-                        rating: {
-                            api_token: 'test_token_rating',
+                        service_rating: {
+                            api_token: 'test_token_service_rating',
                             url: "http://localhost:8006/api/v1/"
                         }
                     },

--- a/test/ussd_public.test.js
+++ b/test/ussd_public.test.js
@@ -2,7 +2,7 @@ var vumigo = require('vumigo_v02');
 var fixtures = require('./fixtures_public');
 var AppTester = vumigo.AppTester;
 
-describe("familyconnect health worker app", function() {
+describe.skip("familyconnect health worker app", function() {
     describe("for ussd use", function() {
         var app;
         var tester;

--- a/test/ussd_public.test.js
+++ b/test/ussd_public.test.js
@@ -2,7 +2,7 @@ var vumigo = require('vumigo_v02');
 var fixtures = require('./fixtures_public');
 var AppTester = vumigo.AppTester;
 
-describe.skip("familyconnect health worker app", function() {
+describe("familyconnect health worker app", function() {
     describe("for ussd use", function() {
         var app;
         var tester;
@@ -258,7 +258,7 @@ describe.skip("familyconnect health worker app", function() {
                         ].join('\n')
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [2]);
+                        go.utils.check_fixtures_used(api, [2,45]);
                     })
                     .run();
             });
@@ -274,7 +274,7 @@ describe.skip("familyconnect health worker app", function() {
                         reply: "Please enter the number you would like to manage. For example 0803304899.  Note: You should permission from the owner to manage this number."
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [2]);
+                        go.utils.check_fixtures_used(api, [2,45]);
                     })
                     .run();
             });
@@ -297,7 +297,7 @@ describe.skip("familyconnect health worker app", function() {
                         ].join('\n')
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [2,3,4]);
+                        go.utils.check_fixtures_used(api, [2,3,4,45]);
                     })
                     .run();
             });
@@ -319,7 +319,7 @@ describe.skip("familyconnect health worker app", function() {
                         ].join('\n')
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [2]);
+                        go.utils.check_fixtures_used(api, [2,45]);
                     })
                     .run();
             });
@@ -367,7 +367,7 @@ describe.skip("familyconnect health worker app", function() {
                         ].join('\n')
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [2,3,4,6,9]);
+                        go.utils.check_fixtures_used(api, [2,3,4,6,9,45]);
                     })
                     .run();
             });
@@ -386,7 +386,7 @@ describe.skip("familyconnect health worker app", function() {
                         reply: "What day of the month did the woman start her last period? For example, 12."
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [2,3,4,6,9]);
+                        go.utils.check_fixtures_used(api, [2,3,4,6,9,45]);
                     })
                     .run();
             });
@@ -410,7 +410,7 @@ describe.skip("familyconnect health worker app", function() {
                         ].join('\n')
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [2,3,4,6,9,10]);
+                        go.utils.check_fixtures_used(api, [2,3,4,6,9,10,45]);
                     })
                     .check.user.answer('state_msg_receiver', 'trusted_friend')
                     .check.user.answer('receiver_id', 'cb245673-aa41-4302-ac47-0000000333')
@@ -442,7 +442,7 @@ describe.skip("familyconnect health worker app", function() {
                         reply: "Thank you. Your FamilyConnect ID is 9999999999. You will receive an SMS with it shortly."
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [2,3,4,5,6,8,9,10,12,13,14,15]);
+                        go.utils.check_fixtures_used(api, [2,3,4,5,6,8,9,10,12,13,14,15,45]);
                     })
                     .run();
             });
@@ -468,7 +468,7 @@ describe.skip("familyconnect health worker app", function() {
                         reply: "Thank you. Your FamilyConnect ID is 5555555555. You will receive an SMS with it shortly."
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [2,6,8,16,17,18,19,20,21]);
+                        go.utils.check_fixtures_used(api, [2,6,8,16,17,18,19,20,21,45]);
                     })
                     .run();
             });
@@ -488,7 +488,7 @@ describe.skip("familyconnect health worker app", function() {
                         reply: "You will receive baby messages."
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [2,26,27,28]);
+                        go.utils.check_fixtures_used(api, [2,26,27,28,45]);
                     })
                     .run();
             });
@@ -510,7 +510,7 @@ describe.skip("familyconnect health worker app", function() {
                         ].join('\n')
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [2,29,30,31]);
+                        go.utils.check_fixtures_used(api, [2,29,30,31,45]);
                     })
                     .run();
             });
@@ -529,7 +529,7 @@ describe.skip("familyconnect health worker app", function() {
                         reply: "Thank you for using the FamilyConnect service"
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [2,29,30,31]);
+                        go.utils.check_fixtures_used(api, [2,29,30,31,45]);
                     })
                     .run();
             });
@@ -547,7 +547,7 @@ describe.skip("familyconnect health worker app", function() {
                         state: 'state_change_menu'
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [2,29,30,31]);
+                        go.utils.check_fixtures_used(api, [2,29,30,31,45]);
                     })
                     .run();
             });
@@ -571,7 +571,7 @@ describe.skip("familyconnect health worker app", function() {
                         ].join('\n')
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [2]);
+                        go.utils.check_fixtures_used(api, [2,45]);
                     })
                     .run();
             });
@@ -589,7 +589,7 @@ describe.skip("familyconnect health worker app", function() {
                         reply: "Thank you. Your language preference has been updated and you will start to receive SMSs in this language."
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [2,22,32,33]);
+                        go.utils.check_fixtures_used(api, [2,22,32,33,45]);
                     })
                     .run();
             });
@@ -607,7 +607,7 @@ describe.skip("familyconnect health worker app", function() {
                         reply: "Please enter the new mobile number you would like to receive weekly messages on. For example 0803304899"
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [2]);
+                        go.utils.check_fixtures_used(api, [2,45]);
                     })
                     .run();
             });
@@ -631,7 +631,7 @@ describe.skip("familyconnect health worker app", function() {
                         ].join('\n')
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [0,2,22,23]);
+                        go.utils.check_fixtures_used(api, [0,2,22,23,45]);
                     })
                     .run();
             });
@@ -650,7 +650,7 @@ describe.skip("familyconnect health worker app", function() {
                         reply: "Thank you. The number which receives messages has been updated."
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [0,2,22,23]);
+                        go.utils.check_fixtures_used(api, [0,2,22,23,45]);
                     })
                     .run();
             });
@@ -672,7 +672,7 @@ describe.skip("familyconnect health worker app", function() {
                         ].join('\n')
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [2,24]);
+                        go.utils.check_fixtures_used(api, [2,24,45]);
                     })
                     .run();
             });
@@ -691,7 +691,7 @@ describe.skip("familyconnect health worker app", function() {
                         reply: "Please enter the new mobile number you would like to receive weekly messages on. For example 0803304899"
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [2,24]);
+                        go.utils.check_fixtures_used(api, [2,24,45]);
                     })
                     .run();
             });
@@ -710,7 +710,7 @@ describe.skip("familyconnect health worker app", function() {
                         reply: "Thank you for using the FamilyConnect service"
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [2,24]);
+                        go.utils.check_fixtures_used(api, [2,24,45]);
                     })
                     .run();
             });
@@ -735,7 +735,7 @@ describe.skip("familyconnect health worker app", function() {
                         ].join('\n')
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [2]);
+                        go.utils.check_fixtures_used(api, [2,45]);
                     })
                     .run();
             });
@@ -757,7 +757,7 @@ describe.skip("familyconnect health worker app", function() {
                         ].join('\n')
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [2]);
+                        go.utils.check_fixtures_used(api, [2,45]);
                     })
                     .run();
             });
@@ -776,7 +776,7 @@ describe.skip("familyconnect health worker app", function() {
                         reply: "Thank you. You will now receive messages to support you during this difficult time."
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [2,34]);
+                        go.utils.check_fixtures_used(api, [2,34,45]);
                     })
                     .run();
             });
@@ -795,7 +795,7 @@ describe.skip("familyconnect health worker app", function() {
                         reply: "Thank you. You will no longer receive messages"
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [2,35,37]);
+                        go.utils.check_fixtures_used(api, [2,35,37,45]);
                     })
                     .run();
             });
@@ -813,7 +813,7 @@ describe.skip("familyconnect health worker app", function() {
                         reply: "Thank you. You will no longer receive messages"
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [2,36,38]);
+                        go.utils.check_fixtures_used(api, [2,36,38,45]);
                     })
                     .run();
             });
@@ -839,7 +839,7 @@ describe.skip("familyconnect health worker app", function() {
                         ].join('\n')
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [39]);
+                        go.utils.check_fixtures_used(api, [39,46]);
                     })
                     .run();
             });
@@ -861,7 +861,7 @@ describe.skip("familyconnect health worker app", function() {
                         ].join('\n')
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [39,40]);
+                        go.utils.check_fixtures_used(api, [39,40,46]);
                     })
                     .run();
             });
@@ -884,7 +884,7 @@ describe.skip("familyconnect health worker app", function() {
                         ].join('\n')
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [39,40,41]);
+                        go.utils.check_fixtures_used(api, [39,40,41,46]);
                     })
                     .run();
             });
@@ -908,7 +908,7 @@ describe.skip("familyconnect health worker app", function() {
                         ].join('\n')
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [39,40,41,42]);
+                        go.utils.check_fixtures_used(api, [39,40,41,42,46]);
                     })
                     .run();
             });
@@ -933,7 +933,7 @@ describe.skip("familyconnect health worker app", function() {
                         ].join('\n')
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [39,40,41,42,43]);
+                        go.utils.check_fixtures_used(api, [39,40,41,42,43,46]);
                     })
                     .run();
             });
@@ -954,7 +954,7 @@ describe.skip("familyconnect health worker app", function() {
                         reply: "Thank you for rating the FamilyConnect service."
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [39,40,41,42,43,44]);
+                        go.utils.check_fixtures_used(api, [39,40,41,42,43,44,46]);
                     })
                     .check.reply.ends_session()
                     .run();

--- a/test/ussd_public.test.js
+++ b/test/ussd_public.test.js
@@ -32,6 +32,10 @@ describe("familyconnect health worker app", function() {
                             api_token: 'test_token_subscriptions',
                             url: "http://localhost:8005/api/v1/"
                         },
+                        servicerating: {
+                            api_token: 'test_token_servingrating',
+                            url: "http://localhost:8006/api/v1/"
+                        }
                     },
                     no_timeout_redirects: [
                         'state_start',
@@ -41,6 +45,7 @@ describe("familyconnect health worker app", function() {
                         'state_end_loss_subscription',
                         'state_end_optout',
                         'state_end_thank_you',
+                        'state_end_servicerating'
                     ],
                     timeout_redirects: [
                         // registration states
@@ -856,7 +861,7 @@ describe("familyconnect health worker app", function() {
                         ].join('\n')
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [39]);
+                        go.utils.check_fixtures_used(api, [39,40]);
                     })
                     .run();
             });
@@ -879,7 +884,7 @@ describe("familyconnect health worker app", function() {
                         ].join('\n')
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [39]);
+                        go.utils.check_fixtures_used(api, [39,40,41]);
                     })
                     .run();
             });
@@ -903,7 +908,7 @@ describe("familyconnect health worker app", function() {
                         ].join('\n')
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [39]);
+                        go.utils.check_fixtures_used(api, [39,40,41,42]);
                     })
                     .run();
             });
@@ -928,7 +933,7 @@ describe("familyconnect health worker app", function() {
                         ].join('\n')
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [39]);
+                        go.utils.check_fixtures_used(api, [39,40,41,42,43]);
                     })
                     .run();
             });
@@ -949,7 +954,7 @@ describe("familyconnect health worker app", function() {
                         reply: "Thank you for rating the FamilyConnect service."
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [39]);
+                        go.utils.check_fixtures_used(api, [39,40,41,42,43,44]);
                     })
                     .check.reply.ends_session()
                     .run();

--- a/test/ussd_public.test.js
+++ b/test/ussd_public.test.js
@@ -954,7 +954,7 @@ describe("familyconnect health worker app", function() {
                         reply: "Thank you for rating the FamilyConnect service."
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [39,40,41,42,43,44,46]);
+                        go.utils.check_fixtures_used(api, [39,40,41,42,43,44,46,47]);
                     })
                     .check.reply.ends_session()
                     .run();

--- a/test/ussd_public.test.js
+++ b/test/ussd_public.test.js
@@ -2,7 +2,7 @@ var vumigo = require('vumigo_v02');
 var fixtures = require('./fixtures_public');
 var AppTester = vumigo.AppTester;
 
-describe.skip("familyconnect health worker app", function() {
+describe("familyconnect health worker app", function() {
     describe("for ussd use", function() {
         var app;
         var tester;

--- a/test/ussd_public.test.js
+++ b/test/ussd_public.test.js
@@ -33,7 +33,7 @@ describe("familyconnect health worker app", function() {
                             url: "http://localhost:8005/api/v1/"
                         },
                         servicerating: {
-                            api_token: 'test_token_servingrating',
+                            api_token: 'test_token_servicerating',
                             url: "http://localhost:8006/api/v1/"
                         }
                     },

--- a/test/ussd_public.test.js
+++ b/test/ussd_public.test.js
@@ -32,8 +32,8 @@ describe("familyconnect health worker app", function() {
                             api_token: 'test_token_subscriptions',
                             url: "http://localhost:8005/api/v1/"
                         },
-                        servicerating: {
-                            api_token: 'test_token_servicerating',
+                        rating: {
+                            api_token: 'test_token_rating',
                             url: "http://localhost:8006/api/v1/"
                         }
                     },


### PR DESCRIPTION
Get the status from the service rating endpoint. Example: https://github.com/praekelt/seed-service-rating/blob/feature/issue-1-initial-port/ratings/tests.py#L164-L172

The results looks like: 

```
{
    "count": 1,
    "next": null,
    "previous": null,
    "details": [{
        "updated_at": "2016-04-04T17:06:08.411867Z",
        "created_at": "2016-04-04T17:06:08.411843Z",
        "version": 1,
        "expired": false,
        "id": "1b47bab8-1c37-44a2-94e6-85c3ee9a8c8b",
        "identity": "210ac8c7-1f23-46af-a186-2468c89f7cc1",
        "completed": false,
        "invited": false,
        "expires_at": null,
        "invite": {
            "content": "Please dial *120*1234# and rate our service",
            "to_addr": "+27123",
            "metadata": {}
        }
    }]
}
```
