### PR TITLE
Combine Head of Household name screens

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -63,6 +63,11 @@ module.exports = function (grunt) {
                     'src/utils_project.js',
                     '<%= paths.src.app.sms_inbound %>',
                     'test/sms_inbound.test.js'
+                ],
+                utils: [
+                    'test/setup.js',
+                    'src/utils',
+                    'test/utils.js'
                 ]
             }
         },
@@ -123,6 +128,9 @@ module.exports = function (grunt) {
             },
             test_sms_inbound: {
                 src: ['<%= paths.test.sms_inbound %>']
+            },
+            test_utils: {
+                src: ['<%= paths.test.utils %>']
             }
         }
     });

--- a/go-app-sms.js
+++ b/go-app-sms.js
@@ -202,6 +202,11 @@ go.utils = {
         return input !== '' && name_check.test(input);
     },
 
+    split_parts: function(input) {
+        // returns an array of an input split by whitespace, or null
+        return input.match(/\S+/g);
+    },
+
     get_clean_first_word: function(user_message) {
         return user_message
             .split(" ")[0]          // split off first word

--- a/go-app-ussd_health_worker.js
+++ b/go-app-ussd_health_worker.js
@@ -1263,7 +1263,7 @@ go.app = function() {
                         return errors[name];
                     }
                     names = go.utils.split_parts(content);
-                    if (!(names instanceof Array) || names.length <= 0){
+                    if (!(names instanceof Array) || names.length === 0){
                         return errors[name];
                     }
                     return null;
@@ -1274,7 +1274,7 @@ go.app = function() {
 
         self.add('check_household_head_name', function(name) {
             names = go.utils.split_parts(self.im.user.answers.state_household_head_name);
-            if (names.length <= 1) {
+            if (names.length === 1) {
                 return self.states.create('state_household_head_surname');
             } else {
                 self.im.user.answers.state_household_head_surname = names.pop();

--- a/go-app-ussd_health_worker.js
+++ b/go-app-ussd_health_worker.js
@@ -202,6 +202,11 @@ go.utils = {
         return input !== '' && name_check.test(input);
     },
 
+    split_parts: function(input) {
+        // returns an array of an input split by whitespace, or null
+        return input.match(/\S+/g);
+    },
+
     get_clean_first_word: function(user_message) {
         return user_message
             .split(" ")[0]          // split off first word
@@ -1249,31 +1254,19 @@ go.app = function() {
                 });
         });
 
-        // FreeText st-03
+        // FreeText st-04
         self.add('state_household_head_name', function(name) {
             return new FreeText(name, {
                 question: questions[name],
                 check: function(content) {
-                    if (go.utils.is_valid_name(content, 1, 150)) {
-                        return null;  // vumi expects null or undefined if check passes
-                    } else {
+                    if (!go.utils.is_valid_name(content, 1, 150)) {
                         return errors[name];
                     }
-                },
-                next: 'state_household_head_surname'
-            });
-        });
-
-        // FreeText st-04
-        self.add('state_household_head_surname', function(name) {
-            return new FreeText(name, {
-                question: questions[name],
-                check: function(content) {
-                    if (go.utils.is_valid_name(content, 1, 150)) {
-                        return null;  // vumi expects null or undefined if check passes
-                    } else {
+                    names = go.utils.split_parts(content);
+                    if (!(names instanceof Array) || names.length <= 1) {
                         return errors[name];
                     }
+                    return null;
                 },
                 next: 'state_last_period_month'
             });
@@ -1465,6 +1458,9 @@ go.app = function() {
                 ],
                 next: function() {
                     self.im.user.answers.state_msg_receiver = 'mother_to_be';
+                    var names = go.utils.split_parts(self.im.user.answers.state_household_head_name);
+                    self.im.user.answers.state_household_head_surname = names.pop();
+                    self.im.user.answers.state_household_head_name = names.join(' ');
                     return go.utils_project
                         .finish_registration(self.im)
                         .then(function() {

--- a/go-app-ussd_health_worker.js
+++ b/go-app-ussd_health_worker.js
@@ -1015,9 +1015,9 @@ go.app = function() {
             "state_msisdn_already_registered":
                 $("{{msisdn}} is already registered for messages."),
             "state_household_head_name":
-                $("Please enter the first name of the Head of the Household. For example: Isaac."),
+                $("Please enter the name and surname of the Head of the Household. For example: Isaac Mbire"),
             "state_household_head_surname":
-                $("Please enter the surname of the Head of the Household. For example: Mbire."),
+                $("You only entered the first name, please enter the surname of the household. For example: Mbire"),
             "state_last_period_month":
                 $("When did the woman have her last period:"),
             "state_last_period_day":
@@ -1054,9 +1054,9 @@ go.app = function() {
             "state_msisdn_already_registered":
                 $("Sorry not a valid input. {{msisdn}} is already registered for messages."),
             "state_household_head_name":
-                $("Sorry not a valid input. Please enter the first name of the Head of the Household. For example: Isaac."),
+                $("Sorry not a valid input. Please enter the name and surname of the Head of the Household. For example: Isaac Mbire"),
             "state_household_head_surname":
-                $("Sorry not a valid input. Please enter the surname of the Head of the Household. For example: Mbire."),
+                $("Sorry not a valid input. Please enter the surname of the Head of the Household. For example: Mbire"),
             "state_last_period_month":
                 $("Sorry not a valid input. When did the woman have her last period:"),
             "state_last_period_day":
@@ -1263,7 +1263,32 @@ go.app = function() {
                         return errors[name];
                     }
                     names = go.utils.split_parts(content);
-                    if (!(names instanceof Array) || names.length <= 1) {
+                    if (!(names instanceof Array) || names.length <= 0){
+                        return errors[name];
+                    }
+                    return null;
+                },
+                next: 'check_household_head_name'
+            });
+        });
+
+        self.add('check_household_head_name', function(name) {
+            names = go.utils.split_parts(self.im.user.answers.state_household_head_name);
+            if (names.length <= 1) {
+                return self.states.create('state_household_head_surname');
+            } else {
+                self.im.user.answers.state_household_head_surname = names.pop();
+                self.im.user.answers.state_household_head_name = names.join(' ');
+                return self.states.create('state_last_period_month');
+            }
+        });
+
+        // FreeText st-13
+        self.add('state_household_head_surname', function(name) {
+            return new FreeText(name, {
+                question: questions[name],
+                check: function(content) {
+                    if (!go.utils.is_valid_name(content, 1, 150)) {
                         return errors[name];
                     }
                     return null;
@@ -1271,6 +1296,7 @@ go.app = function() {
                 next: 'state_last_period_month'
             });
         });
+
 
         // ChoiceState st-05
         self.add('state_last_period_month', function(name) {
@@ -1458,9 +1484,6 @@ go.app = function() {
                 ],
                 next: function() {
                     self.im.user.answers.state_msg_receiver = 'mother_to_be';
-                    var names = go.utils.split_parts(self.im.user.answers.state_household_head_name);
-                    self.im.user.answers.state_household_head_surname = names.pop();
-                    self.im.user.answers.state_household_head_name = names.join(' ');
                     return go.utils_project
                         .finish_registration(self.im)
                         .then(function() {

--- a/go-app-ussd_public.js
+++ b/go-app-ussd_public.js
@@ -202,6 +202,11 @@ go.utils = {
         return input !== '' && name_check.test(input);
     },
 
+    split_parts: function(input) {
+        // returns an array of an input split by whitespace, or null
+        return input.match(/\S+/g);
+    },
+
     get_clean_first_word: function(user_message) {
         return user_message
             .split(" ")[0]          // split off first word

--- a/src/ussd_health_worker.js
+++ b/src/ussd_health_worker.js
@@ -267,31 +267,19 @@ go.app = function() {
                 });
         });
 
-        // FreeText st-03
+        // FreeText st-04
         self.add('state_household_head_name', function(name) {
             return new FreeText(name, {
                 question: questions[name],
                 check: function(content) {
-                    if (go.utils.is_valid_name(content, 1, 150)) {
-                        return null;  // vumi expects null or undefined if check passes
-                    } else {
+                    if (!go.utils.is_valid_name(content, 1, 150)) {
                         return errors[name];
                     }
-                },
-                next: 'state_household_head_surname'
-            });
-        });
-
-        // FreeText st-04
-        self.add('state_household_head_surname', function(name) {
-            return new FreeText(name, {
-                question: questions[name],
-                check: function(content) {
-                    if (go.utils.is_valid_name(content, 1, 150)) {
-                        return null;  // vumi expects null or undefined if check passes
-                    } else {
+                    names = go.utils.split_parts(content);
+                    if (!(names instanceof Array) || names.length <= 1) {
                         return errors[name];
                     }
+                    return null;
                 },
                 next: 'state_last_period_month'
             });
@@ -483,6 +471,9 @@ go.app = function() {
                 ],
                 next: function() {
                     self.im.user.answers.state_msg_receiver = 'mother_to_be';
+                    var names = go.utils.split_parts(self.im.user.answers.state_household_head_name);
+                    self.im.user.answers.state_household_head_surname = names.pop();
+                    self.im.user.answers.state_household_head_name = names.join(' ');
                     return go.utils_project
                         .finish_registration(self.im)
                         .then(function() {

--- a/src/ussd_health_worker.js
+++ b/src/ussd_health_worker.js
@@ -28,9 +28,9 @@ go.app = function() {
             "state_msisdn_already_registered":
                 $("{{msisdn}} is already registered for messages."),
             "state_household_head_name":
-                $("Please enter the first name of the Head of the Household. For example: Isaac."),
+                $("Please enter the name and surname of the Head of the Household. For example: Isaac Mbire"),
             "state_household_head_surname":
-                $("Please enter the surname of the Head of the Household. For example: Mbire."),
+                $("You only entered the first name, please enter the surname of the household. For example: Mbire"),
             "state_last_period_month":
                 $("When did the woman have her last period:"),
             "state_last_period_day":
@@ -67,9 +67,9 @@ go.app = function() {
             "state_msisdn_already_registered":
                 $("Sorry not a valid input. {{msisdn}} is already registered for messages."),
             "state_household_head_name":
-                $("Sorry not a valid input. Please enter the first name of the Head of the Household. For example: Isaac."),
+                $("Sorry not a valid input. Please enter the name and surname of the Head of the Household. For example: Isaac Mbire"),
             "state_household_head_surname":
-                $("Sorry not a valid input. Please enter the surname of the Head of the Household. For example: Mbire."),
+                $("Sorry not a valid input. Please enter the surname of the Head of the Household. For example: Mbire"),
             "state_last_period_month":
                 $("Sorry not a valid input. When did the woman have her last period:"),
             "state_last_period_day":
@@ -276,7 +276,32 @@ go.app = function() {
                         return errors[name];
                     }
                     names = go.utils.split_parts(content);
-                    if (!(names instanceof Array) || names.length <= 1) {
+                    if (!(names instanceof Array) || names.length <= 0){
+                        return errors[name];
+                    }
+                    return null;
+                },
+                next: 'check_household_head_name'
+            });
+        });
+
+        self.add('check_household_head_name', function(name) {
+            names = go.utils.split_parts(self.im.user.answers.state_household_head_name);
+            if (names.length <= 1) {
+                return self.states.create('state_household_head_surname');
+            } else {
+                self.im.user.answers.state_household_head_surname = names.pop();
+                self.im.user.answers.state_household_head_name = names.join(' ');
+                return self.states.create('state_last_period_month');
+            }
+        });
+
+        // FreeText st-13
+        self.add('state_household_head_surname', function(name) {
+            return new FreeText(name, {
+                question: questions[name],
+                check: function(content) {
+                    if (!go.utils.is_valid_name(content, 1, 150)) {
                         return errors[name];
                     }
                     return null;
@@ -284,6 +309,7 @@ go.app = function() {
                 next: 'state_last_period_month'
             });
         });
+
 
         // ChoiceState st-05
         self.add('state_last_period_month', function(name) {
@@ -471,9 +497,6 @@ go.app = function() {
                 ],
                 next: function() {
                     self.im.user.answers.state_msg_receiver = 'mother_to_be';
-                    var names = go.utils.split_parts(self.im.user.answers.state_household_head_name);
-                    self.im.user.answers.state_household_head_surname = names.pop();
-                    self.im.user.answers.state_household_head_name = names.join(' ');
                     return go.utils_project
                         .finish_registration(self.im)
                         .then(function() {

--- a/src/ussd_health_worker.js
+++ b/src/ussd_health_worker.js
@@ -276,7 +276,7 @@ go.app = function() {
                         return errors[name];
                     }
                     names = go.utils.split_parts(content);
-                    if (!(names instanceof Array) || names.length <= 0){
+                    if (!(names instanceof Array) || names.length === 0){
                         return errors[name];
                     }
                     return null;
@@ -287,7 +287,7 @@ go.app = function() {
 
         self.add('check_household_head_name', function(name) {
             names = go.utils.split_parts(self.im.user.answers.state_household_head_name);
-            if (names.length <= 1) {
+            if (names.length === 1) {
                 return self.states.create('state_household_head_surname');
             } else {
                 self.im.user.answers.state_household_head_surname = names.pop();

--- a/src/utils.js
+++ b/src/utils.js
@@ -195,6 +195,11 @@ go.utils = {
         return input !== '' && name_check.test(input);
     },
 
+    split_parts: function(input) {
+        // returns an array of an input split by whitespace, or null
+        return input.match(/\S+/g);
+    },
+
     get_clean_first_word: function(user_message) {
         return user_message
             .split(" ")[0]          // split off first word

--- a/test/ussd_health_worker.test.js
+++ b/test/ussd_health_worker.test.js
@@ -193,24 +193,6 @@ describe("familyconnect health worker app", function() {
                     .check.user.answer('ff_id', undefined)
                     .run();
             });
-            it("to state_household_head_surname", function() {
-                return tester
-                    .setup.user.addr('0820000111')
-                    .inputs(
-                        {session_event: 'new'}  // dial in
-                        , '12345'  // state_auth_code - personnel code
-                        , '0820000333'  // state_msisdn
-                        , 'Isaac'  // state_household_head_name
-                    )
-                    .check.interaction({
-                        state: 'state_household_head_surname',
-                        reply: "Please enter the surname of the Head of the Household. For example: Mbire."
-                    })
-                    .check(function(api) {
-                        go.utils.check_fixtures_used(api, [0,5,6,17]);
-                    })
-                    .run();
-            });
             it("to state_last_period_month", function() {
                 return tester
                     .setup.user.addr('0820000111')
@@ -218,8 +200,7 @@ describe("familyconnect health worker app", function() {
                         {session_event: 'new'}  // dial in
                         , '12345'  // state_auth_code - personnel code
                         , '0820000333'  // state_msisdn
-                        , 'Isaac'  // state_household_head_name
-                        , 'Mbire'  // state_household_head_surname
+                        , 'Isaac Mbire'  // state_household_head_name
                     )
                     .check.interaction({
                         state: 'state_last_period_month',
@@ -245,8 +226,7 @@ describe("familyconnect health worker app", function() {
                         {session_event: 'new'}  // dial in
                         , '12345'  // state_auth_code - personnel code
                         , '0820000333'  // state_msisdn
-                        , 'Isaac'  // state_household_head_name
-                        , 'Mbire'  // state_household_head_surname
+                        , 'Isaac Mbire'  // state_household_head_name
                         , '1'  // state_last_period_month - july 2015
                     )
                     .check.interaction({
@@ -262,8 +242,7 @@ describe("familyconnect health worker app", function() {
                         {session_event: 'new'}  // dial in
                         , '12345'  // state_auth_code - personnel code
                         , '0820000333'  // state_msisdn
-                        , 'Isaac'  // state_household_head_name
-                        , 'Mbire'  // state_household_head_surname
+                        , 'Isaac Mbire'  // state_household_head_name
                         , '1'  // state_last_period_month - july 2015
                         , '21'  // state_last_period_day - 21st
                     )
@@ -280,8 +259,7 @@ describe("familyconnect health worker app", function() {
                         {session_event: 'new'}  // dial in
                         , '12345'  // state_auth_code - personnel code
                         , '0820000333'  // state_msisdn
-                        , 'Isaac'  // state_household_head_name
-                        , 'Mbire'  // state_household_head_surname
+                        , 'Isaac Mbire'  // state_household_head_name
                         , '1'  // state_last_period_month - july 2015
                         , '21'  // state_last_period_day - 21st
                         , 'Sharon'  // state_mother_name
@@ -299,8 +277,7 @@ describe("familyconnect health worker app", function() {
                         {session_event: 'new'}  // dial in
                         , '12345'  // state_auth_code - personnel code
                         , '0820000333'  // state_msisdn
-                        , 'Isaac'  // state_household_head_name
-                        , 'Mbire'  // state_household_head_surname
+                        , 'Isaac Mbire'  // state_household_head_name
                         , '1'  // state_last_period_month - july 2015
                         , '21'  // state_last_period_day - 21st
                         , 'Sharon'  // state_mother_name
@@ -324,8 +301,7 @@ describe("familyconnect health worker app", function() {
                         {session_event: 'new'}  // dial in
                         , '12345'  // state_auth_code - personnel code
                         , '0820000333'  // state_msisdn
-                        , 'Isaac'  // state_household_head_name
-                        , 'Mbire'  // state_household_head_surname
+                        , 'Isaac Mbire'  // state_household_head_name
                         , '1'  // state_last_period_month - july 2015
                         , '21'  // state_last_period_day - 21st
                         , 'Sharon'  // state_mother_name
@@ -345,8 +321,7 @@ describe("familyconnect health worker app", function() {
                         {session_event: 'new'}  // dial in
                         , '12345'  // state_auth_code - personnel code
                         , '0820000333'  // state_msisdn
-                        , 'Isaac'  // state_household_head_name
-                        , 'Mbire'  // state_household_head_surname
+                        , 'Isaac Mbire'  // state_household_head_name
                         , '1'  // state_last_period_month - july 2015
                         , '21'  // state_last_period_day - 21st
                         , 'Sharon'  // state_mother_name
@@ -374,8 +349,7 @@ describe("familyconnect health worker app", function() {
                         {session_event: 'new'}  // dial in
                         , '12345'  // state_auth_code - personnel code
                         , '0820000333'  // state_msisdn
-                        , 'Isaac'  // state_household_head_name
-                        , 'Mbire'  // state_household_head_surname
+                        , 'Isaac Mbire'  // state_household_head_name
                         , '1'  // state_last_period_month - july 2015
                         , '21'  // state_last_period_day - 21st
                         , 'Sharon'  // state_mother_name
@@ -395,8 +369,7 @@ describe("familyconnect health worker app", function() {
                         {session_event: 'new'}  // dial in
                         , '12345'  // state_auth_code - personnel code
                         , '0820000333'  // state_msisdn
-                        , 'Isaac'  // state_household_head_name
-                        , 'Mbire'  // state_household_head_surname
+                        , 'Isaac Mbire'  // state_household_head_name
                         , '1'  // state_last_period_month - july 2015
                         , '21'  // state_last_period_day - 21st
                         , 'Sharon'  // state_mother_name
@@ -431,8 +404,7 @@ describe("familyconnect health worker app", function() {
                         {session_event: 'new'}  // dial in
                         , '12345'  // state_auth_code - personnel code
                         , '0820000333'  // state_msisdn
-                        , 'Isaac'  // state_household_head_name
-                        , 'Mbire'  // state_household_head_surname
+                        , 'Isaac Mbire'  // state_household_head_name
                         , '1'  // state_last_period_month - july 2015
                         , '21'  // state_last_period_day - 21st
                         , 'Sharon'  // state_mother_name
@@ -454,8 +426,7 @@ describe("familyconnect health worker app", function() {
                         {session_event: 'new'}  // dial in
                         , '12345'  // state_auth_code - personnel code
                         , '0820000333'  // state_msisdn
-                        , 'Isaac'  // state_household_head_name
-                        , 'Mbire'  // state_household_head_surname
+                        , 'Isaac Mbire'  // state_household_head_name
                         , '1'  // state_last_period_month - july 2015
                         , '21'  // state_last_period_day - 21st
                         , 'Sharon'  // state_mother_name
@@ -485,8 +456,7 @@ describe("familyconnect health worker app", function() {
                         {session_event: 'new'}  // dial in
                         , '12345'  // state_auth_code - personnel code
                         , '0820000333'  // state_msisdn
-                        , 'Isaac'  // state_household_head_name
-                        , 'Mbire'  // state_household_head_surname
+                        , 'Isaac Mbire'  // state_household_head_name
                         , '1'  // state_last_period_month - july 2015
                         , '21'  // state_last_period_day - 21st
                         , 'Sharon'  // state_mother_name
@@ -516,8 +486,7 @@ describe("familyconnect health worker app", function() {
                         {session_event: 'new'}  // dial in
                         , '12345'  // state_auth_code - personnel code
                         , '0820000333'  // state_msisdn
-                        , 'Isaac'  // state_household_head_name
-                        , 'Mbire'  // state_household_head_surname
+                        , 'Isaac Mbire'  // state_household_head_name
                         , '1'  // state_last_period_month - July 2015
                         , '21'  // state_last_period_day - 21st
                         , 'Mary'  // state_mother_name

--- a/test/ussd_health_worker.test.js
+++ b/test/ussd_health_worker.test.js
@@ -182,7 +182,7 @@ describe("familyconnect health worker app", function() {
                     )
                     .check.interaction({
                         state: 'state_household_head_name',
-                        reply: "Please enter the first name of the Head of the Household. For example: Isaac."
+                        reply: "Please enter the name and surname of the Head of the Household. For example: Isaac Mbire"
                     })
                     .check(function(api) {
                         go.utils.check_fixtures_used(api, [0,5,6,17]);
@@ -536,7 +536,7 @@ describe("familyconnect health worker app", function() {
                     )
                     .check.interaction({
                         state: 'state_household_head_name',
-                        reply: "Sorry not a valid input. Please enter the first name of the Head of the Household. For example: Isaac."
+                        reply: "Sorry not a valid input. Please enter the name and surname of the Head of the Household. For example: Isaac Mbire"
                     })
                     .run();
             });

--- a/test/ussd_health_worker.test.js
+++ b/test/ussd_health_worker.test.js
@@ -193,7 +193,44 @@ describe("familyconnect health worker app", function() {
                     .check.user.answer('ff_id', undefined)
                     .run();
             });
-            it("to state_last_period_month", function() {
+            it("to state_household_head_surname (mother, unrecognised)", function() {
+                return tester
+                    .setup.user.addr('0820000111')
+                    .inputs(
+                        {session_event: 'new'}  // dial in
+                        , '12345'  // state_auth_code - personnel code
+                        , '0820000333'  // state_msisdn
+                        , 'Isaac' // state_household_head_name
+                    )
+                    .check.interaction({
+                        state: 'state_household_head_surname',
+                        reply: "You only entered the first name, please enter the surname of the household. For example: Mbire"
+                    })
+                    .check(function(api) {
+                        go.utils.check_fixtures_used(api, [0,5,6,17]);
+                    })
+                    .check.user.answer('receiver_id', 'identity-uuid-06')
+                    .check.user.answer('mother_id', 'identity-uuid-06')
+                    .check.user.answer('hoh_id', 'identity-uuid-17')
+                    .check.user.answer('ff_id', undefined)
+                    .check.user.answer('state_household_head_name', 'Isaac')
+                    .run();
+            });
+            it("to state_last_period_month (one name)", function() {
+                return tester
+                    .setup.user.addr('0820000111')
+                    .inputs(
+                        {session_event: 'new'}  // dial in
+                        , '12345'  // state_auth_code - personnel code
+                        , '0820000333'  // state_msisdn
+                        , 'Isaac'  // state_household_head_name
+                        , 'Mbire'  // state_household_head_surname
+                    )
+                    .check.user.answer('state_household_head_name', 'Isaac')
+                    .check.user.answer('state_household_head_surname', 'Mbire')
+                    .run();
+            });
+            it("to state_last_period_month (two names)", function() {
                 return tester
                     .setup.user.addr('0820000111')
                     .inputs(
@@ -217,6 +254,21 @@ describe("familyconnect health worker app", function() {
                             "9. Aug 14"
                         ].join('\n')
                     })
+                    .check.user.answer('state_household_head_name', 'Isaac')
+                    .check.user.answer('state_household_head_surname', 'Mbire')
+                    .run();
+            });
+            it("to state_last_period_month (three names)", function() {
+                return tester
+                    .setup.user.addr('0820000111')
+                    .inputs(
+                        {session_event: 'new'}  // dial in
+                        , '12345'  // state_auth_code - personnel code
+                        , '0820000333'  // state_msisdn
+                        , 'Isaac Birungi Mbire'  // state_household_head_name
+                    )
+                    .check.user.answer('state_household_head_name', 'Isaac Birungi')
+                    .check.user.answer('state_household_head_surname', 'Mbire')
                     .run();
             });
             it("to state_last_period_day", function() {

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,31 @@
+var vumigo = require('vumigo_v02');
+var fixtures = require('./fixtures');
+var assert = require('assert');
+var AppTester = vumigo.AppTester;
+
+describe("text utils", function() {
+    describe("split_parts", function() {
+        it("should ignore leading and lagging whitespace", function() {
+            assert.deepEqual(
+                go.utils.split_parts("  a  "),
+                ["a"]
+            );
+        });
+        it("should return null if there are no characters", function() {
+            assert.deepEqual(
+                go.utils.split_parts("  "),
+                null
+            );
+            assert.deepEqual(
+                go.utils.split_parts(""),
+                null
+            );
+        });
+        it("should ignore multiple whitespace characters between words", function() {
+            assert.deepEqual(
+                go.utils.split_parts("  a  b  "),
+                ["a", "b"]
+            );
+        });
+    });
+});


### PR DESCRIPTION
As a result of UET testing, we want to combine the name and surname screens for the Head of Household into a single name and surname screen.

The name and surnames will be separated by whitespace, and there can be multiple words for the name, but only one word for the surname.

If only one word is entered for the name screen, an error is returned to the user, and they are asked to input the surname. The entry in the first screen is kept as the name.
