### PR TITLE
Remove ID collection screens

### DIFF
--- a/go-app-ussd_health_worker.js
+++ b/go-app-ussd_health_worker.js
@@ -990,7 +990,6 @@ go.app = function() {
     var App = vumigo.App;
     var Choice = vumigo.states.Choice;
     var ChoiceState = vumigo.states.ChoiceState;
-    var PaginatedChoiceState = vumigo.states.PaginatedChoiceState;
     var EndState = vumigo.states.EndState;
     var FreeText = vumigo.states.FreeText;
 
@@ -1026,16 +1025,6 @@ go.app = function() {
                 $("Please enter the name of the woman. For example: Sharon"),
             "state_mother_surname":
                 $("Please enter the surname of the woman. For example: Nalule"),
-            "state_id_type":
-                $("What kind of identification does the woman have?"),
-            "state_nin":
-                $("Please enter the woman's National Identity Number:"),
-            "state_mother_birth_day":
-                $("Please enter the day the woman was born. For example, 12."),
-            "state_mother_birth_month":
-                $("Please select the month of birth:"),
-            "state_mother_birth_year":
-                $("Please enter the year the mother was born. For example, 1986."),
             "state_msg_language":
                 $("What language would they want to receive these messages in?"),
             "state_end_thank_you":
@@ -1063,16 +1052,6 @@ go.app = function() {
                 $("Sorry not a valid input. Please enter the name of the woman. For example: Sharon"),
             "state_mother_surname":
                 $("Sorry not a valid input. Please enter the surname of the woman. For example: Nalule"),
-            "state_id_type":
-                $("Sorry not a valid input. What kind of identification does the woman have?"),
-            "state_nin":
-                $("Sorry not a valid input. Please enter the woman's National Identity Number:"),
-            "state_mother_birth_day":
-                $("Sorry not a valid input. Please enter the day the woman was born. For example, 12."),
-            "state_mother_birth_month":
-                $("Sorry not a valid input. Please select the month of birth:"),
-            "state_mother_birth_year":
-                $("Sorry not a valid input. Please enter the year the mother was born. For example, 1986."),
             "state_msg_language":
                 $("Sorry not a valid input. What language would they want to receive these messages in?"),
             "state_end_thank_you":
@@ -1352,96 +1331,7 @@ go.app = function() {
                         return errors[name];
                     }
                 },
-                next: 'state_id_type'
-            });
-        });
-
-        // ChoiceState st-09
-        self.add('state_id_type', function(name) {
-            return new ChoiceState(name, {
-                question: questions[name],
-                error: errors[name],
-                choices: [
-                    new Choice('ugandan_id', $("Ugandan National Identity Number")),
-                    new Choice('other', $("Other"))
-                ],
-                next: function(choice) {
-                    return choice.value === 'ugandan_id'
-                        ? 'state_nin'
-                        : 'state_mother_birth_day';
-                }
-            });
-        });
-
-        // FreeText st-10
-        self.add('state_nin', function(name) {
-            return new FreeText(name, {
-                question: questions[name],
                 next: 'state_msg_language'
-            });
-        });
-
-        // FreeText st-17
-        self.add('state_mother_birth_day', function(name) {
-            return new FreeText(name, {
-                question: questions[name],
-                check: function(content) {
-                    if (go.utils.is_valid_day_of_month(content)) {
-                        return null;  // vumi expects null or undefined if check passes
-                    } else {
-                        return errors[name];
-                    }
-                },
-                next: 'state_mother_birth_month'
-            });
-        });
-
-        // PaginatedChoiceState st-18 / st-19
-        self.add('state_mother_birth_month', function(name) {
-            return new PaginatedChoiceState(name, {
-                question: questions[name],
-                error: errors[name],
-                characters_per_page: 160,
-                options_per_page: null,
-                more: $('More'),
-                back: $('Back'),
-                choices: [
-                    new Choice('01', $('January')),
-                    new Choice('02', $('February')),
-                    new Choice('03', $('March')),
-                    new Choice('04', $('April')),
-                    new Choice('05', $('May')),
-                    new Choice('06', $('June')),
-                    new Choice('07', $('July')),
-                    new Choice('08', $('August')),
-                    new Choice('09', $('September')),
-                    new Choice('10', $('October')),
-                    new Choice('11', $('November')),
-                    new Choice('12', $('December'))
-                ],
-                next: 'state_mother_birth_year'
-            });
-        });
-
-        // FreeText st-20
-        self.add('state_mother_birth_year', function(name) {
-            return new FreeText(name, {
-                question: questions[name],
-                check: function(content) {
-                    if (go.utils.is_valid_year(content, '1900', go.utils.get_today(self.im.config).format('YYYY'))) {
-                        return null;  // vumi expects null or undefined if check passes
-                    } else {
-                        return errors[name];
-                    }
-                },
-                next: function(content) {
-                    var year = content;
-                    var month = self.im.user.answers.state_mother_birth_month;
-                    var day = go.utils.double_digit_number(
-                        self.im.user.answers.state_mother_birth_day);
-                    self.im.user.set_answer('mother_dob', year+month+day);
-                    return 'state_msg_language';
-                }
             });
         });
 

--- a/src/ussd_health_worker.js
+++ b/src/ussd_health_worker.js
@@ -3,7 +3,6 @@ go.app = function() {
     var App = vumigo.App;
     var Choice = vumigo.states.Choice;
     var ChoiceState = vumigo.states.ChoiceState;
-    var PaginatedChoiceState = vumigo.states.PaginatedChoiceState;
     var EndState = vumigo.states.EndState;
     var FreeText = vumigo.states.FreeText;
 
@@ -39,16 +38,6 @@ go.app = function() {
                 $("Please enter the name of the woman. For example: Sharon"),
             "state_mother_surname":
                 $("Please enter the surname of the woman. For example: Nalule"),
-            "state_id_type":
-                $("What kind of identification does the woman have?"),
-            "state_nin":
-                $("Please enter the woman's National Identity Number:"),
-            "state_mother_birth_day":
-                $("Please enter the day the woman was born. For example, 12."),
-            "state_mother_birth_month":
-                $("Please select the month of birth:"),
-            "state_mother_birth_year":
-                $("Please enter the year the mother was born. For example, 1986."),
             "state_msg_language":
                 $("What language would they want to receive these messages in?"),
             "state_end_thank_you":
@@ -76,16 +65,6 @@ go.app = function() {
                 $("Sorry not a valid input. Please enter the name of the woman. For example: Sharon"),
             "state_mother_surname":
                 $("Sorry not a valid input. Please enter the surname of the woman. For example: Nalule"),
-            "state_id_type":
-                $("Sorry not a valid input. What kind of identification does the woman have?"),
-            "state_nin":
-                $("Sorry not a valid input. Please enter the woman's National Identity Number:"),
-            "state_mother_birth_day":
-                $("Sorry not a valid input. Please enter the day the woman was born. For example, 12."),
-            "state_mother_birth_month":
-                $("Sorry not a valid input. Please select the month of birth:"),
-            "state_mother_birth_year":
-                $("Sorry not a valid input. Please enter the year the mother was born. For example, 1986."),
             "state_msg_language":
                 $("Sorry not a valid input. What language would they want to receive these messages in?"),
             "state_end_thank_you":
@@ -365,96 +344,7 @@ go.app = function() {
                         return errors[name];
                     }
                 },
-                next: 'state_id_type'
-            });
-        });
-
-        // ChoiceState st-09
-        self.add('state_id_type', function(name) {
-            return new ChoiceState(name, {
-                question: questions[name],
-                error: errors[name],
-                choices: [
-                    new Choice('ugandan_id', $("Ugandan National Identity Number")),
-                    new Choice('other', $("Other"))
-                ],
-                next: function(choice) {
-                    return choice.value === 'ugandan_id'
-                        ? 'state_nin'
-                        : 'state_mother_birth_day';
-                }
-            });
-        });
-
-        // FreeText st-10
-        self.add('state_nin', function(name) {
-            return new FreeText(name, {
-                question: questions[name],
                 next: 'state_msg_language'
-            });
-        });
-
-        // FreeText st-17
-        self.add('state_mother_birth_day', function(name) {
-            return new FreeText(name, {
-                question: questions[name],
-                check: function(content) {
-                    if (go.utils.is_valid_day_of_month(content)) {
-                        return null;  // vumi expects null or undefined if check passes
-                    } else {
-                        return errors[name];
-                    }
-                },
-                next: 'state_mother_birth_month'
-            });
-        });
-
-        // PaginatedChoiceState st-18 / st-19
-        self.add('state_mother_birth_month', function(name) {
-            return new PaginatedChoiceState(name, {
-                question: questions[name],
-                error: errors[name],
-                characters_per_page: 160,
-                options_per_page: null,
-                more: $('More'),
-                back: $('Back'),
-                choices: [
-                    new Choice('01', $('January')),
-                    new Choice('02', $('February')),
-                    new Choice('03', $('March')),
-                    new Choice('04', $('April')),
-                    new Choice('05', $('May')),
-                    new Choice('06', $('June')),
-                    new Choice('07', $('July')),
-                    new Choice('08', $('August')),
-                    new Choice('09', $('September')),
-                    new Choice('10', $('October')),
-                    new Choice('11', $('November')),
-                    new Choice('12', $('December'))
-                ],
-                next: 'state_mother_birth_year'
-            });
-        });
-
-        // FreeText st-20
-        self.add('state_mother_birth_year', function(name) {
-            return new FreeText(name, {
-                question: questions[name],
-                check: function(content) {
-                    if (go.utils.is_valid_year(content, '1900', go.utils.get_today(self.im.config).format('YYYY'))) {
-                        return null;  // vumi expects null or undefined if check passes
-                    } else {
-                        return errors[name];
-                    }
-                },
-                next: function(content) {
-                    var year = content;
-                    var month = self.im.user.answers.state_mother_birth_month;
-                    var day = go.utils.double_digit_number(
-                        self.im.user.answers.state_mother_birth_day);
-                    self.im.user.set_answer('mother_dob', year+month+day);
-                    return 'state_msg_language';
-                }
             });
         });
 

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -764,8 +764,6 @@ return [
                         "hoh_surname": "Mbire",
                         "mama_name": "Mary",
                         "mama_surname": "Nalule",
-                        "mama_id_type": "other",
-                        "mama_dob": "19820513"
                     }
                 }
             },
@@ -803,8 +801,6 @@ return [
                         "first_name": "Mary",
                         "surname": "Nalule",
                         "name": "Mary Nalule",
-                        "id_type": "other",
-                        "dob": "19820513"
                     },
                 }
             },

--- a/test/ussd_health_worker.test.js
+++ b/test/ussd_health_worker.test.js
@@ -156,7 +156,6 @@ describe("familyconnect health worker app", function() {
                     .setup.user.addr('0820000111')
                     .inputs(
                         {session_event: 'new'}  // dial in
-                        , '12345'  // state_auth_code - personnel code
                         , '0820000444'  // state_msisdn
                     )
                     .check.interaction({
@@ -177,7 +176,6 @@ describe("familyconnect health worker app", function() {
                     .setup.user.addr('0820000111')
                     .inputs(
                         {session_event: 'new'}  // dial in
-                        , '12345'  // state_auth_code - personnel code
                         , '0820000333'  // state_msisdn
                     )
                     .check.interaction({
@@ -198,7 +196,6 @@ describe("familyconnect health worker app", function() {
                     .setup.user.addr('0820000111')
                     .inputs(
                         {session_event: 'new'}  // dial in
-                        , '12345'  // state_auth_code - personnel code
                         , '0820000333'  // state_msisdn
                         , 'Isaac' // state_household_head_name
                     )
@@ -221,7 +218,6 @@ describe("familyconnect health worker app", function() {
                     .setup.user.addr('0820000111')
                     .inputs(
                         {session_event: 'new'}  // dial in
-                        , '12345'  // state_auth_code - personnel code
                         , '0820000333'  // state_msisdn
                         , 'Isaac'  // state_household_head_name
                         , 'Mbire'  // state_household_head_surname
@@ -235,7 +231,6 @@ describe("familyconnect health worker app", function() {
                     .setup.user.addr('0820000111')
                     .inputs(
                         {session_event: 'new'}  // dial in
-                        , '12345'  // state_auth_code - personnel code
                         , '0820000333'  // state_msisdn
                         , 'Isaac Mbire'  // state_household_head_name
                     )
@@ -263,7 +258,6 @@ describe("familyconnect health worker app", function() {
                     .setup.user.addr('0820000111')
                     .inputs(
                         {session_event: 'new'}  // dial in
-                        , '12345'  // state_auth_code - personnel code
                         , '0820000333'  // state_msisdn
                         , 'Isaac Birungi Mbire'  // state_household_head_name
                     )
@@ -276,7 +270,6 @@ describe("familyconnect health worker app", function() {
                     .setup.user.addr('0820000111')
                     .inputs(
                         {session_event: 'new'}  // dial in
-                        , '12345'  // state_auth_code - personnel code
                         , '0820000333'  // state_msisdn
                         , 'Isaac Mbire'  // state_household_head_name
                         , '1'  // state_last_period_month - july 2015
@@ -292,7 +285,6 @@ describe("familyconnect health worker app", function() {
                     .setup.user.addr('0820000111')
                     .inputs(
                         {session_event: 'new'}  // dial in
-                        , '12345'  // state_auth_code - personnel code
                         , '0820000333'  // state_msisdn
                         , 'Isaac Mbire'  // state_household_head_name
                         , '1'  // state_last_period_month - july 2015
@@ -309,7 +301,6 @@ describe("familyconnect health worker app", function() {
                     .setup.user.addr('0820000111')
                     .inputs(
                         {session_event: 'new'}  // dial in
-                        , '12345'  // state_auth_code - personnel code
                         , '0820000333'  // state_msisdn
                         , 'Isaac Mbire'  // state_household_head_name
                         , '1'  // state_last_period_month - july 2015
@@ -322,64 +313,17 @@ describe("familyconnect health worker app", function() {
                     })
                     .run();
             });
-            it("to state_id_type", function() {
+            it("to state_msg_language", function() {
                 return tester
                     .setup.user.addr('0820000111')
                     .inputs(
                         {session_event: 'new'}  // dial in
-                        , '12345'  // state_auth_code - personnel code
                         , '0820000333'  // state_msisdn
                         , 'Isaac Mbire'  // state_household_head_name
                         , '1'  // state_last_period_month - july 2015
                         , '21'  // state_last_period_day - 21st
                         , 'Sharon'  // state_mother_name
                         , 'Nalule'  // state_mother_surname
-                    )
-                    .check.interaction({
-                        state: 'state_id_type',
-                        reply: [
-                            "What kind of identification does the woman have?",
-                            "1. Ugandan National Identity Number",
-                            "2. Other"
-                        ].join('\n')
-                    })
-                    .run();
-            });
-
-            it("to state_nin", function() {
-                return tester
-                    .setup.user.addr('0820000111')
-                    .inputs(
-                        {session_event: 'new'}  // dial in
-                        , '12345'  // state_auth_code - personnel code
-                        , '0820000333'  // state_msisdn
-                        , 'Isaac Mbire'  // state_household_head_name
-                        , '1'  // state_last_period_month - july 2015
-                        , '21'  // state_last_period_day - 21st
-                        , 'Sharon'  // state_mother_name
-                        , 'Nalule'  // state_mother_surname
-                        , '1'  // state_id_type - ugandan id
-                    )
-                    .check.interaction({
-                        state: 'state_nin',
-                        reply: "Please enter the woman's National Identity Number:"
-                    })
-                    .run();
-            });
-            it("to state_msg_language (NIN)", function() {
-                return tester
-                    .setup.user.addr('0820000111')
-                    .inputs(
-                        {session_event: 'new'}  // dial in
-                        , '12345'  // state_auth_code - personnel code
-                        , '0820000333'  // state_msisdn
-                        , 'Isaac Mbire'  // state_household_head_name
-                        , '1'  // state_last_period_month - july 2015
-                        , '21'  // state_last_period_day - 21st
-                        , 'Sharon'  // state_mother_name
-                        , 'Nalule'  // state_mother_surname
-                        , '1'  // state_id_type - ugandan id
-                        , '444'  // state_nin
                     )
                     .check.interaction({
                         state: 'state_msg_language',
@@ -394,129 +338,17 @@ describe("familyconnect health worker app", function() {
                     .run();
             });
 
-            it("to state_mother_birth_day", function() {
+            it("complete flow - mother, lusoga, no hiv msgs", function() {
                 return tester
                     .setup.user.addr('0820000111')
                     .inputs(
                         {session_event: 'new'}  // dial in
-                        , '12345'  // state_auth_code - personnel code
-                        , '0820000333'  // state_msisdn
-                        , 'Isaac Mbire'  // state_household_head_name
-                        , '1'  // state_last_period_month - july 2015
-                        , '21'  // state_last_period_day - 21st
-                        , 'Sharon'  // state_mother_name
-                        , 'Nalule'  // state_mother_surname
-                        , '2'  // state_id_type - other
-                    )
-                    .check.interaction({
-                        state: 'state_mother_birth_day',
-                        reply: "Please enter the day the woman was born. For example, 12."
-                    })
-                    .run();
-            });
-            it("to state_mother_birth_month", function() {
-                return tester
-                    .setup.user.addr('0820000111')
-                    .inputs(
-                        {session_event: 'new'}  // dial in
-                        , '12345'  // state_auth_code - personnel code
-                        , '0820000333'  // state_msisdn
-                        , 'Isaac Mbire'  // state_household_head_name
-                        , '1'  // state_last_period_month - july 2015
-                        , '21'  // state_last_period_day - 21st
-                        , 'Sharon'  // state_mother_name
-                        , 'Nalule'  // state_mother_surname
-                        , '2'  // state_id_type - other
-                        , '13'  // state_mother_birth_day - 13th
-                    )
-                    .check.interaction({
-                        state: 'state_mother_birth_month',
-                        reply: [
-                            "Please select the month of birth:",
-                            "1. January",
-                            "2. February",
-                            "3. March",
-                            "4. April",
-                            "5. May",
-                            "6. June",
-                            "7. July",
-                            "8. August",
-                            "9. September",
-                            "10. October",
-                            "11. November",
-                            "12. December"
-                        ].join('\n')
-                    })
-                    .run();
-            });
-            it("to state_mother_birth_year", function() {
-                return tester
-                    .setup.user.addr('0820000111')
-                    .inputs(
-                        {session_event: 'new'}  // dial in
-                        , '12345'  // state_auth_code - personnel code
-                        , '0820000333'  // state_msisdn
-                        , 'Isaac Mbire'  // state_household_head_name
-                        , '1'  // state_last_period_month - july 2015
-                        , '21'  // state_last_period_day - 21st
-                        , 'Sharon'  // state_mother_name
-                        , 'Nalule'  // state_mother_surname
-                        , '2'  // state_id_type - other
-                        , '13'  // state_mother_birth_day - 13th
-                        , '5'  // state_mother_birth_month - may
-                    )
-                    .check.interaction({
-                        state: 'state_mother_birth_year',
-                        reply: "Please enter the year the mother was born. For example, 1986."
-                    })
-                    .run();
-            });
-            it("to state_msg_language (Other)", function() {
-                return tester
-                    .setup.user.addr('0820000111')
-                    .inputs(
-                        {session_event: 'new'}  // dial in
-                        , '12345'  // state_auth_code - personnel code
-                        , '0820000333'  // state_msisdn
-                        , 'Isaac Mbire'  // state_household_head_name
-                        , '1'  // state_last_period_month - july 2015
-                        , '21'  // state_last_period_day - 21st
-                        , 'Sharon'  // state_mother_name
-                        , 'Nalule'  // state_mother_surname
-                        , '2'  // state_id_type - other
-                        , '13'  // state_mother_birth_day - 13th
-                        , '5'  // state_mother_birth_month - may
-                        , '1982'  // state_mother_birth_year - 1982
-                    )
-                    .check.interaction({
-                        state: 'state_msg_language',
-                        reply: [
-                            "What language would they want to receive these messages in?",
-                            "1. English",
-                            "2. Rukiga",
-                            "3. Lusoga",
-                            "4. Luganda"
-                        ].join('\n')
-                    })
-                    .run();
-            });
-
-            it("complete flow - mother, other ID, lusoga, no hiv msgs", function() {
-                return tester
-                    .setup.user.addr('0820000111')
-                    .inputs(
-                        {session_event: 'new'}  // dial in
-                        , '12345'  // state_auth_code - personnel code
                         , '0820000333'  // state_msisdn
                         , 'Isaac Mbire'  // state_household_head_name
                         , '1'  // state_last_period_month - July 2015
                         , '21'  // state_last_period_day - 21st
                         , 'Mary'  // state_mother_name
                         , 'Nalule'  // state_mother_surname
-                        , '2'  // state_id_type - other ID
-                        , '13'  // state_mother_birth_day - 13th
-                        , '5'  // state_mother_birth_month - may
-                        , '1982'  // state_mother_birth_year - 1982
                         , '3'  // state_msg_language - lusoga
                     )
                     .check.interaction({


### PR DESCRIPTION
From the results of the UET, we no longer want the ID type selection screen, or any of the ID input screens.

Note: This will require an update in the django app to pass registrations even though they don't have any ID information.
