### PR TITLE
Remove HIV messages selection screen

### DIFF
--- a/go-app-ussd_public.js
+++ b/go-app-ussd_public.js
@@ -1049,8 +1049,6 @@ go.app = function() {
                 $("When did the woman have her last period"),
             "state_last_period_day":
                 $("What day of the month did the woman start her last period? For example, 12."),
-            "state_hiv_messages":
-                $("Would they like to receive additional messages about HIV?"),
             "state_end_thank_you":
                 $("Thank you. Your FamilyConnect ID is {{health_id}}. You will receive an SMS with it shortly."),
 
@@ -1103,8 +1101,6 @@ go.app = function() {
                 $("Sorry not a valid input. When did the woman have her last period"),
             "state_last_period_day":
                 $("Sorry not a valid input. What day of the month did the woman start her last period? For example, 12."),
-            "state_hiv_messages":
-                $("Sorry not a valid input. Would they like to receive additional messages about HIV?"),
             "state_end_thank_you":
                 $("Sorry not a valid input. Thank you. Your FamilyConnect ID is {{health_id}}. You will receive an SMS with it shortly."),
 
@@ -1611,27 +1607,17 @@ go.app = function() {
                     } else {
                         self.im.user.set_answer('health_id', 'no_health_id_found');
                     }
-                    return self.states.create('state_hiv_messages');
+                    return self.states.create('state_finish_registration');
                 });
         });
 
-        // ChoiceState st-12
-        self.add('state_hiv_messages', function(name) {
-            return new ChoiceState(name, {
-                question: questions[name],
-                error: errors[name],
-                choices: [
-                    new Choice('yes_hiv_msgs', $('Yes')),
-                    new Choice('no_hiv_msgs', $('No'))
-                ],
-                next: function() {
-                    return go.utils_project
-                        .finish_public_registration(self.im)
-                        .then(function() {
-                            return 'state_end_thank_you';
-                        });
-                }
-            });
+        // Delegation state to finish registration
+        self.add('state_finish_registration', function(name) {
+            return go.utils_project
+                .finish_public_registration(self.im)
+                .then(function() {
+                    return self.states.create('state_end_thank_you');
+                });
         });
 
         // EndState st-13

--- a/src/ussd_public.js
+++ b/src/ussd_public.js
@@ -62,8 +62,6 @@ go.app = function() {
                 $("When did the woman have her last period"),
             "state_last_period_day":
                 $("What day of the month did the woman start her last period? For example, 12."),
-            "state_hiv_messages":
-                $("Would they like to receive additional messages about HIV?"),
             "state_end_thank_you":
                 $("Thank you. Your FamilyConnect ID is {{health_id}}. You will receive an SMS with it shortly."),
 
@@ -116,8 +114,6 @@ go.app = function() {
                 $("Sorry not a valid input. When did the woman have her last period"),
             "state_last_period_day":
                 $("Sorry not a valid input. What day of the month did the woman start her last period? For example, 12."),
-            "state_hiv_messages":
-                $("Sorry not a valid input. Would they like to receive additional messages about HIV?"),
             "state_end_thank_you":
                 $("Sorry not a valid input. Thank you. Your FamilyConnect ID is {{health_id}}. You will receive an SMS with it shortly."),
 
@@ -624,27 +620,17 @@ go.app = function() {
                     } else {
                         self.im.user.set_answer('health_id', 'no_health_id_found');
                     }
-                    return self.states.create('state_hiv_messages');
+                    return self.states.create('state_finish_registration');
                 });
         });
 
-        // ChoiceState st-12
-        self.add('state_hiv_messages', function(name) {
-            return new ChoiceState(name, {
-                question: questions[name],
-                error: errors[name],
-                choices: [
-                    new Choice('yes_hiv_msgs', $('Yes')),
-                    new Choice('no_hiv_msgs', $('No'))
-                ],
-                next: function() {
-                    return go.utils_project
-                        .finish_public_registration(self.im)
-                        .then(function() {
-                            return 'state_end_thank_you';
-                        });
-                }
-            });
+        // Delegation state to finish registration
+        self.add('state_finish_registration', function(name) {
+            return go.utils_project
+                .finish_public_registration(self.im)
+                .then(function() {
+                    return self.states.create('state_end_thank_you');
+                });
         });
 
         // EndState st-13

--- a/test/fixtures_public.js
+++ b/test/fixtures_public.js
@@ -673,8 +673,7 @@ return [
                     "msg_receiver": "mother_to_be",
                     "role": "mother",
                     "hoh_id": "identity-uuid-06",
-                    "preferred_msg_type": "text",
-                    "hiv_interest": "yes_hiv_msgs"
+                    "preferred_msg_type": "text"
                 }
             }
         },

--- a/test/ussd_public.test.js
+++ b/test/ussd_public.test.js
@@ -51,7 +51,6 @@ describe("familyconnect health worker app", function() {
                         // registration states
                         'state_last_period_month',
                         'state_last_period_day',
-                        'state_hiv_messages',
                     ],
                 })
                 .setup(function(api) {
@@ -329,34 +328,6 @@ describe("familyconnect health worker app", function() {
                     })
                     .run();
             });
-            it("to state_hiv_messages", function() {
-                return tester
-                    .setup.user.addr('0720000111')
-                    .inputs(
-                        {session_event: 'new'}  // dial in
-                        , "1"  // state_language - English
-                        , "2"  // state_choose_number - change number to manage
-                        , "0720000333"  // state_manage_msisdn - unregistered user
-                        , "3"  // state_last_period_month - may
-                        , "22"  // state_last_period_day
-                    )
-                    .check.interaction({
-                        state: 'state_hiv_messages',
-                        reply: [
-                            "Would they like to receive additional messages about HIV?",
-                            "1. Yes",
-                            "2. No"
-                        ].join('\n')
-                    })
-                    .check(function(api) {
-                        go.utils.check_fixtures_used(api, [0,1,3,4,5,6]);
-                    })
-                    .check.user.answer('state_msg_receiver', 'mother_to_be')
-                    .check.user.answer('receiver_id', 'cb245673-aa41-4302-ac47-0000000333')
-                    .check.user.answer('mother_id', 'cb245673-aa41-4302-ac47-0000000333')
-                    .check.user.answer('hoh_id', 'identity-uuid-06')
-                    .run();
-            });
 
             it("complete flow - mother_to_be", function() {
                 return tester
@@ -368,7 +339,6 @@ describe("familyconnect health worker app", function() {
                         , "0720000555"  // state_manage_msisdn - unregistered user
                         , "3"  // state_last_period_month - feb 15
                         , "22"  // state_last_period_day - 22
-                        , "1"  // state_hiv_messages - yes
                     )
                     .check.user.answer('state_msg_receiver', 'mother_to_be')
                     .check.user.answer('receiver_id', 'cb245673-aa41-4302-ac47-0000000555')


### PR DESCRIPTION
As part of the UET results, we want to remove the HIV messaging selection screen, and not send that choice along with the registration.
