### PR TITLE
Add VHT cellphone number lookup

### DIFF
--- a/go-app-sms.js
+++ b/go-app-sms.js
@@ -644,6 +644,8 @@ go.utils_project = {
                 msg_type: "text",
                 last_period_date: im.user.answers.last_period_date,
                 msg_receiver: im.user.answers.state_msg_receiver,
+                parish: im.user.answers.parish,
+                vht_personnel_code: im.user.answers.vht_personnel_code,
             }
         };
 

--- a/go-app-ussd_health_worker.js
+++ b/go-app-ussd_health_worker.js
@@ -644,6 +644,8 @@ go.utils_project = {
                 msg_type: "text",
                 last_period_date: im.user.answers.last_period_date,
                 msg_receiver: im.user.answers.state_msg_receiver,
+                parish: im.user.answers.parish,
+                vht_personnel_code: im.user.answers.vht_personnel_code,
             }
         };
 

--- a/go-app-ussd_public.js
+++ b/go-app-ussd_public.js
@@ -644,6 +644,8 @@ go.utils_project = {
                 msg_type: "text",
                 last_period_date: im.user.answers.last_period_date,
                 msg_receiver: im.user.answers.state_msg_receiver,
+                parish: im.user.answers.parish,
+                vht_personnel_code: im.user.answers.vht_personnel_code,
             }
         };
 
@@ -993,6 +995,7 @@ go.app = function() {
     var ChoiceState = vumigo.states.ChoiceState;
     var EndState = vumigo.states.EndState;
     var FreeText = vumigo.states.FreeText;
+    var MenuState = vumigo.states.MenuState;
 
 
     var GoFC = App.extend(function(self) {
@@ -1045,10 +1048,17 @@ go.app = function() {
                 $("Thank you. You will now receive messages to support you during this difficult time."),
             "state_end_optout":
                 $("Thank you. You will no longer receive messages"),
+
             "state_last_period_month":
                 $("When did the woman have her last period"),
             "state_last_period_day":
                 $("What day of the month did the woman start her last period? For example, 12."),
+            "state_cellphone_or_search":
+                $("Do you know your local village health team (VHT)?"),
+            "state_vht_cellphone_number":
+                $("Please enter their cellphone number. For example, 0803304899"),
+            "state_check_vht_exists":
+                $("We did not recognise the VHTs number."),
             "state_end_thank_you":
                 $("Thank you. Your FamilyConnect ID is {{health_id}}. You will receive an SMS with it shortly."),
 
@@ -1101,6 +1111,12 @@ go.app = function() {
                 $("Sorry not a valid input. When did the woman have her last period"),
             "state_last_period_day":
                 $("Sorry not a valid input. What day of the month did the woman start her last period? For example, 12."),
+            "state_cellphone_or_search":
+                $("Sorry not a valid input. Do you know your local village health team (VHT)?"),
+            "state_vht_cellphone_number":
+                $("Sorry not a valid input. Please enter their cellphone number. For example, 0803304899"),
+            "state_check_vht_exists":
+                $("Sorry not a valid input. We did not recognise the VHTs number."),
             "state_end_thank_you":
                 $("Sorry not a valid input. Thank you. Your FamilyConnect ID is {{health_id}}. You will receive an SMS with it shortly."),
 
@@ -1566,7 +1582,7 @@ go.app = function() {
                 });
         });
 
-        // ChoiceState st-05
+        // ChoiceState reg-02
         self.add('state_last_period_month', function(name) {
             var today = go.utils.get_today(self.im.config);
             return new ChoiceState(name, {
@@ -1577,7 +1593,7 @@ go.app = function() {
             });
         });
 
-        // FreeText st-06
+        // FreeText reg-03
         self.add('state_last_period_day', function(name) {
             return new FreeText(name, {
                 question: questions[name],
@@ -1607,8 +1623,48 @@ go.app = function() {
                     } else {
                         self.im.user.set_answer('health_id', 'no_health_id_found');
                     }
-                    return self.states.create('state_finish_registration');
+                    return self.states.create('state_cellphone_or_search');
                 });
+        });
+
+        // ChoiceState reg-04
+        self.add('state_cellphone_or_search', function(name) {
+            return new MenuState(name, {
+                question: questions[name],
+                choices: [
+                    new Choice('state_vht_cellphone_number', $("Yes"))
+                ]
+            });
+        });
+
+        // FreeText reg-10
+        self.add('state_vht_cellphone_number', function(name) {
+            return new FreeText(name, {
+                question: questions[name],
+                next: 'state_check_vht_exists'
+            });
+        });
+
+        // ChoiceState reg-11
+        self.add('state_check_vht_exists', function(name) {
+            var number = go.utils.normalize_msisdn(
+                self.im.user.answers.state_vht_cellphone_number, self.im.config.country_code);
+            return go.utils.get_identity_by_address({'msisdn': number}, self.im).then(function(identity) {
+                if (
+                        identity === null || identity.details === undefined ||
+                        identity.details.parish === undefined || identity.details.personnel_code === undefined) {
+                    return new MenuState(name, {
+                        question: questions[name],
+                        choices: [
+                            new Choice('state_vht_cellphone_number', $("Try again"))
+                        ]
+                    });
+                } else {
+                    self.im.user.set_answer('vht_personnel_code', identity.details.personnel_code);
+                    self.im.user.set_answer('parish', identity.details.parish);
+                    return self.states.create('state_finish_registration');
+                }
+            });
         });
 
         // Delegation state to finish registration
@@ -1620,7 +1676,7 @@ go.app = function() {
                 });
         });
 
-        // EndState st-13
+        // EndState reg-07
         self.add('state_end_thank_you', function(name) {
             var text =
                 self.im.user.answers.health_id === 'no_health_id_found'

--- a/src/utils_project.js
+++ b/src/utils_project.js
@@ -85,6 +85,8 @@ go.utils_project = {
                 msg_type: "text",
                 last_period_date: im.user.answers.last_period_date,
                 msg_receiver: im.user.answers.state_msg_receiver,
+                parish: im.user.answers.parish,
+                vht_personnel_code: im.user.answers.vht_personnel_code,
             }
         };
 

--- a/test/fixtures_public.js
+++ b/test/fixtures_public.js
@@ -6,6 +6,7 @@
 // 0720000555: unregistered user - number entered manually - mother_to_be registration
 // 0720000666: registered user - has baby(postbirth) subscription
 // 0720000777: registered user - servicerating_unanswered flag set to true
+// 0720000999: registered VHT with personnel code and parish
 
 module.exports = function() {
 return [
@@ -640,7 +641,9 @@ return [
                     "language": "eng_UG",
                     "msg_type": "text",
                     "last_period_date": "20150222",
-                    "msg_receiver": "mother_to_be"
+                    "msg_receiver": "mother_to_be",
+                    "parish": "Kawaaga",
+                    "vht_personnel_code": "888"
                 }
             }
         },
@@ -1518,6 +1521,50 @@ return [
             "code": 200,
             "data": {
                 "success": "true"
+            }
+        }
+    },
+
+    // 48: get identity 0720000999 by msisdn
+    {
+        'repeatable': true,
+        'request': {
+            'method': 'GET',
+            'params': {
+                'details__addresses__msisdn': '+256720000999'
+            },
+            'headers': {
+                'Authorization': ['Token test_key'],
+                'Content-Type': ['application/json']
+            },
+            'url': 'http://localhost:8001/api/v1/identities/search/',
+        },
+        'response': {
+            "code": 200,
+            "data": {
+                "count": 1,
+                "next": null,
+                "previous": null,
+                "results": [{
+                    "url": "http://localhost:8001/api/v1/identities/3f7c8851-5204-43f7-af7f-000000000999/",
+                    "id": "3f7c8851-5204-43f7-af7f-000000000999",
+                    "version": 1,
+                    "details": {
+                        "default_addr_type": "msisdn",
+                        "addresses": {
+                            "msisdn": {
+                                "+256720000222": {}
+                            }
+                        },
+                        "role": "vht",
+                        "preferred_msg_type": "sms",
+                        "preferred_language": "eng_UG",
+                        "parish": "Kawaaga",
+                        "personnel_code": "888",
+                    },
+                    "created_at": "2015-07-10T06:13:29.693272Z",
+                    "updated_at": "2015-07-10T06:13:29.693298Z"
+                }]
             }
         }
     },

--- a/test/ussd_public.test.js
+++ b/test/ussd_public.test.js
@@ -329,6 +329,78 @@ describe("familyconnect health worker app", function() {
                     .run();
             });
 
+            it("to state_cellphone_or_search", function() {
+                return tester
+                    .setup.user.addr('0720000111')
+                    .inputs(
+                        {session_event: 'new'}  // dial in
+                        , "1"  // state_language - English
+                        , "2"  // state_choose_number - change number to manage
+                        , "0720000333"  // state_manage_msisdn - unregistered user
+                        , "3"  // state_last_period_month - may
+                        , "22"  // state_last_period_day - 22
+                    )
+                    .check.interaction({
+                        state: 'state_cellphone_or_search',
+                        reply: [
+                            "Do you know your local village health team (VHT)?",
+                            "1. Yes"
+                        ].join('\n')
+                    })
+                    .check(function(api) {
+                        go.utils.check_fixtures_used(api, [0,1,3,4,5,6]);
+                    })
+                    .run();
+            });
+
+            it("to state_vht_cellphone_number", function() {
+                return tester
+                    .setup.user.addr('0720000111')
+                    .inputs(
+                        {session_event: 'new'}  // dial in
+                        , "1"  // state_language - English
+                        , "2"  // state_choose_number - change number to manage
+                        , "0720000333"  // state_manage_msisdn - unregistered user
+                        , "3"  // state_last_period_month - may
+                        , "22"  // state_last_period_day - 22
+                        , "1"  // state_cellphone_or_search - cellphone
+                    )
+                    .check.interaction({
+                        state: 'state_vht_cellphone_number',
+                        reply: "Please enter their cellphone number. For example, 0803304899"
+                    })
+                    .check(function(api) {
+                        go.utils.check_fixtures_used(api, [0,1,3,4,5,6]);
+                    })
+                    .run();
+            });
+
+            it("to state_check_vht_exists", function() {
+                return tester
+                    .setup.user.addr('0720000111')
+                    .inputs(
+                        {session_event: 'new'}  // dial in
+                        , "1"  // state_language - English
+                        , "2"  // state_choose_number - change number to manage
+                        , "0720000333"  // state_manage_msisdn - unregistered user
+                        , "3"  // state_last_period_month - may
+                        , "22"  // state_last_period_day - 22
+                        , "1"  // state_cellphone_or_search - cellphone
+                        , "0720000111" // state_check_vht_exists, invalid vht
+                    )
+                    .check.interaction({
+                        state: 'state_check_vht_exists',
+                        reply: [
+                            "We did not recognise the VHTs number.",
+                            "1. Try again"
+                        ].join('\n')
+                    })
+                    .check(function(api) {
+                        go.utils.check_fixtures_used(api, [0,1,3,4,5,6]);
+                    })
+                    .run();
+            });
+
             it("complete flow - mother_to_be", function() {
                 return tester
                     .setup.user.addr('0720000111')
@@ -339,18 +411,22 @@ describe("familyconnect health worker app", function() {
                         , "0720000555"  // state_manage_msisdn - unregistered user
                         , "3"  // state_last_period_month - feb 15
                         , "22"  // state_last_period_day - 22
+                        , "1"  // state_cellphone_or_search - cellphone
+                        , "0720000999" // state_vht_cellphone_number, valid VHT
                     )
                     .check.user.answer('state_msg_receiver', 'mother_to_be')
                     .check.user.answer('receiver_id', 'cb245673-aa41-4302-ac47-0000000555')
                     .check.user.answer('mother_id', 'cb245673-aa41-4302-ac47-0000000555')
                     .check.user.answer('hoh_id', 'identity-uuid-06')
                     .check.user.answer('ff_id', undefined)
+                    .check.user.answer('parish', 'Kawaaga')
+                    .check.user.answer('vht_personnel_code', '888')
                     .check.interaction({
                         state: 'state_end_thank_you',
                         reply: "Thank you. Your FamilyConnect ID is 5555555555. You will receive an SMS with it shortly."
                     })
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [0,1,6,8,16,17,18,19,20,21]);
+                        go.utils.check_fixtures_used(api, [0,1,6,8,16,17,18,19,20,21,48]);
                     })
                     .run();
             });


### PR DESCRIPTION
As part of the UET results, we want the user to be add their location during registration, either through finding their VHT through cellphone number, or by searching their parish name.

This PR deals with finding their VHT by using a cellphone number.
