### PR TITLE
Add location search

### DIFF
--- a/go-app-ussd_public.js
+++ b/go-app-ussd_public.js
@@ -1720,7 +1720,7 @@ go.app = function() {
                         exit: $("Exit"),
                         options_per_page: 4,
                         next: function(choice) {
-                            switch (choice.label) {
+                            switch (choice.value) {
                                 case '__retry__':
                                     return 'state_retry_parish_search';
                                 case '__exit__':

--- a/src/ussd_public.js
+++ b/src/ussd_public.js
@@ -70,6 +70,14 @@ go.app = function() {
                 $("Please enter their cellphone number. For example, 0803304899"),
             "state_check_vht_exists":
                 $("We did not recognise the VHTs number."),
+            "state_parish_search":
+                $("What is the name of your parish?"),
+            "state_select_parish":
+                $("Results for {{search}}:"),
+            "state_no_parish_results":
+                $("Sorry, there are no results for your parish name."),
+            "state_retry_parish_search":
+                $("Please re-enter your parish name carefully and make sure you use the correct spelling."),
             "state_end_thank_you":
                 $("Thank you. Your FamilyConnect ID is {{health_id}}. You will receive an SMS with it shortly."),
 
@@ -128,6 +136,14 @@ go.app = function() {
                 $("Sorry not a valid input. Please enter their cellphone number. For example, 0803304899"),
             "state_check_vht_exists":
                 $("Sorry not a valid input. We did not recognise the VHTs number."),
+            "state_parish_search":
+                $("Sorry not a valid input. What is the name of your parish?"),
+            "state_select_parish":
+                $("Sorry not a valid input. Results for {{search}}"),
+            "state_no_parish_results":
+                $("Sorry, not a valid input. Sorry, there are no results for your parish name."),
+            "state_retry_parish_search":
+                $("Sorry, not a valid input. Please re-enter your parish name carefully and make sure you use the correct spelling."),
             "state_end_thank_you":
                 $("Sorry not a valid input. Thank you. Your FamilyConnect ID is {{health_id}}. You will receive an SMS with it shortly."),
 
@@ -643,7 +659,70 @@ go.app = function() {
             return new MenuState(name, {
                 question: questions[name],
                 choices: [
-                    new Choice('state_vht_cellphone_number', $("Yes"))
+                    new Choice('state_vht_cellphone_number', $("Yes")),
+                    new Choice('state_parish_search', $("No"))
+                ]
+            });
+        });
+
+        // FreeText reg-05
+        self.add('state_parish_search', function(name) {
+            return new FreeText(name, {
+                question: questions[name],
+                next: 'state_select_parish'
+            });
+        });
+
+        // ChoiceState reg-06
+        self.add('state_select_parish', function(name) {
+            return go.utils_project
+                .parish_search(self.im.user.answers.state_parish_search, self.im)
+                .then(function(parishes) {
+                    if (parishes.length === 0) {
+                        return self.states.create('state_no_parish_results');
+                    }
+                    return new go.utils_project.ParishPaginatedChoiceState(name, {
+                        question: questions[name].context({search: self.im.user.answers.state_parish_search}),
+                        choices: parishes.map(function(p) { return new Choice(p.name, p.name); }),
+                        error: errors[name],
+                        back: $("Back"),
+                        more: $("More"),
+                        retry: $("Try again"),
+                        exit: $("Exit"),
+                        options_per_page: 4,
+                        next: function(choice) {
+                            switch (choice.label) {
+                                case '__retry__':
+                                    return 'state_retry_parish_search';
+                                case '__exit__':
+                                    return 'state_finish_registration';
+                                default:
+                                    self.im.user.set_answer('parish', choice.label);
+                                    return 'state_finish_registration';
+                            }
+                        }
+                    });
+                });
+        });
+
+        // Freetext reg-08
+        self.add('state_retry_parish_search', function(name) {
+            return new FreeText(name, {
+                question: questions[name],
+                next: function(text) {
+                    self.im.user.set_answer('state_parish_search', text);
+                    return 'state_select_parish';
+                }
+            });
+        });
+
+        // ChoiceState reg-09
+        self.add('state_no_parish_results', function(name) {
+            return new MenuState(name, {
+                question: questions[name],
+                choices: [
+                    new Choice('state_retry_parish_search', $("Try again")),
+                    new Choice('state_finish_registration', $("Exit"))
                 ]
             });
         });
@@ -667,7 +746,8 @@ go.app = function() {
                     return new MenuState(name, {
                         question: questions[name],
                         choices: [
-                            new Choice('state_vht_cellphone_number', $("Try again"))
+                            new Choice('state_vht_cellphone_number', $("Try again")),
+                            new Choice('state_parish_search', $("Enter your location instead"))
                         ]
                     });
                 } else {
@@ -677,6 +757,7 @@ go.app = function() {
                 }
             });
         });
+
 
         // Delegation state to finish registration
         self.add('state_finish_registration', function(name) {

--- a/src/ussd_public.js
+++ b/src/ussd_public.js
@@ -691,7 +691,7 @@ go.app = function() {
                         exit: $("Exit"),
                         options_per_page: 4,
                         next: function(choice) {
-                            switch (choice.label) {
+                            switch (choice.value) {
                                 case '__retry__':
                                     return 'state_retry_parish_search';
                                 case '__exit__':

--- a/src/utils_project.js
+++ b/src/utils_project.js
@@ -1,5 +1,8 @@
 /*jshint -W083 */
 var Q = require('q');
+var vumigo = require('vumigo_v02');
+var Choice = vumigo.states.Choice;
+var PaginatedChoiceState = vumigo.states.PaginatedChoiceState;
 
 
 // Project utils libraty
@@ -424,6 +427,43 @@ go.utils_project = {
             });
     },
 
+
+    // PARISH SEACH HELPERS
+
+    // searches for parish by name
+    parish_search: function(name, im) {
+        return go.utils
+            .service_api_call("registrations", "get", {'name': name}, null, "parish/", im)
+            .then(function(response) {
+                // The results are paginated, but the default pagination limit is 1000,
+                // and we don't want the user to have to go through more than that.
+                return response.data.results;
+            });
+    },
+
+    ParishPaginatedChoiceState: PaginatedChoiceState.extend(function(self, name, opts) {
+        // A choice state for displaying the list of parishes. Adds the __retry__ and __exit__ choices, which
+        // must be handled in the state's next function.
+        PaginatedChoiceState.call(self, name, opts);
+
+        self.retry = new Choice("__retry__", opts.retry);
+        self.exit = new Choice("__exit__", opts.exit);
+
+        var super_translate = self.translate;
+        self.translate = function(i18n) {
+            super_translate.call(self, i18n);
+            self.retry.label = i18n(self.retry.label);
+            self.exit.label = i18n(self.exit.label);
+        };
+
+        var super_current_choices = self.current_choices;
+        self.current_choices = function() {
+            var choices = super_current_choices();
+            choices.push(self.retry);
+            choices.push(self.exit);
+            return choices;
+        };
+    }),
 
     "commas": "commas"
 };

--- a/test/fixtures_public.js
+++ b/test/fixtures_public.js
@@ -1569,5 +1569,89 @@ return [
         }
     },
 
+    // 49: search for parish "kawa" 5 results
+    {
+        'repeatable': true,
+        'request': {
+            'method': 'GET',
+            'params': {
+                'name': 'kawa'
+            },
+            'headers': {
+                'Authorization': ['Token test_token_registrations'],
+                'Content-Type': ['application/json']
+            },
+            'url': 'http://localhost:8002/api/v1/parish/',
+        },
+        'response': {
+            'code': 200,
+            'data': {
+                'count': 5,
+                'next': null,
+                'previous': null,
+                'results': [
+                    { 'name': 'Kawaaga' },
+                    { 'name': 'Balawoli' },
+                    { 'name': 'Kagumba' },
+                    { 'name': 'Kasolwe' },
+                    { 'name': 'Kibuye' },
+                ]
+            }
+        }
+    },
+
+    // 50: search for parish "foo" no results
+    {
+        'request': {
+            'method': 'GET',
+            'params': {
+                'name': 'foo'
+            },
+            'headers': {
+                'Authorization': ['Token test_token_registrations'],
+                'Content-Type': ['application/json']
+            },
+            'url': 'http://localhost:8002/api/v1/parish/',
+        },
+        'response': {
+            'code': 200,
+            'data': {
+                'count': 5,
+                'next': null,
+                'previous': null,
+                'results': []
+            }
+        }
+    },
+
+    // 51: create registration 3
+    {
+        'request': {
+            'method': 'POST',
+            'headers': {
+                'Authorization': ['Token test_key'],
+                'Content-Type': ['application/json']
+            },
+            'url': 'http://localhost:8002/api/v1/registration/',
+            'data':  {
+                "stage": "prebirth",
+                "mother_id": "cb245673-aa41-4302-ac47-0000000555",
+                "data": {
+                    "hoh_id": "identity-uuid-06",
+                    "receiver_id": "cb245673-aa41-4302-ac47-0000000555",
+                    "operator_id": null,
+                    "language": "eng_UG",
+                    "msg_type": "text",
+                    "last_period_date": "20150222",
+                    "msg_receiver": "mother_to_be",
+                    "parish": "Kawaaga",
+                }
+            }
+        },
+        'response': {
+            "code": 201,
+            "data": {}
+        }
+    },
 ];
 };

--- a/test/ussd_public.test.js
+++ b/test/ussd_public.test.js
@@ -344,7 +344,8 @@ describe("familyconnect health worker app", function() {
                         state: 'state_cellphone_or_search',
                         reply: [
                             "Do you know your local village health team (VHT)?",
-                            "1. Yes"
+                            "1. Yes",
+                            "2. No"
                         ].join('\n')
                     })
                     .check(function(api) {
@@ -392,7 +393,8 @@ describe("familyconnect health worker app", function() {
                         state: 'state_check_vht_exists',
                         reply: [
                             "We did not recognise the VHTs number.",
-                            "1. Try again"
+                            "1. Try again",
+                            "2. Enter your location instead"
                         ].join('\n')
                     })
                     .check(function(api) {
@@ -401,7 +403,114 @@ describe("familyconnect health worker app", function() {
                     .run();
             });
 
-            it("complete flow - mother_to_be", function() {
+            it("to state_parish_search", function() {
+                return tester
+                    .setup.user.addr('0720000111')
+                    .inputs(
+                        {session_event: 'new'}  // dial in
+                        , "1"  // state_language - English
+                        , "2"  // state_choose_number - change number to manage
+                        , "0720000333"  // state_manage_msisdn - unregistered user
+                        , "3"  // state_last_period_month - may
+                        , "22"  // state_last_period_day - 22
+                        , "2"  // state_cellphone_or_search - search
+                    )
+                    .check.interaction({
+                        state: 'state_parish_search',
+                        reply: "What is the name of your parish?"
+                    })
+                    .check(function(api) {
+                        go.utils.check_fixtures_used(api, [0,1,3,4,5,6]);
+                    })
+                    .run()
+            });
+
+            it("to state_select_parish", function() {
+                return tester
+                    .setup.user.addr('0720000111')
+                    .inputs(
+                        {session_event: 'new'}  // dial in
+                        , "1"  // state_language - English
+                        , "2"  // state_choose_number - change number to manage
+                        , "0720000333"  // state_manage_msisdn - unregistered user
+                        , "3"  // state_last_period_month - may
+                        , "22"  // state_last_period_day - 22
+                        , "2"  // state_cellphone_or_search - search
+                        , "kawa" // state_parish_search - search for "kawa", 5 results
+                    )
+                    .check.interaction({
+                        state: 'state_select_parish',
+                        reply: [
+                            "Results for kawa:",
+                            "1. Kawaaga",
+                            "2. Balawoli",
+                            "3. Kagumba",
+                            "4. Kasolwe",
+                            "5. More",
+                            "6. Try again",
+                            "7. Exit"
+                        ].join('\n')
+                    })
+                    .check(function(api) {
+                        go.utils.check_fixtures_used(api, [0,1,3,4,5,6,49]);
+                    })
+                    .run()
+            });
+
+            it("to state_no_parish_results", function() {
+                return tester
+                    .setup.user.addr('0720000111')
+                    .inputs(
+                        {session_event: 'new'}  // dial in
+                        , "1"  // state_language - English
+                        , "2"  // state_choose_number - change number to manage
+                        , "0720000333"  // state_manage_msisdn - unregistered user
+                        , "3"  // state_last_period_month - may
+                        , "22"  // state_last_period_day - 22
+                        , "2"  // state_cellphone_or_search - search
+                        , "foo" // state_parish_search - search for "foo", no results
+                    )
+                    .check.interaction({
+                        state: 'state_no_parish_results',
+                        reply: [
+                            "Sorry, there are no results for your parish name.",
+                            "1. Try again",
+                            "2. Exit"
+                        ].join('\n')
+                    })
+                    .check(function(api) {
+                        go.utils.check_fixtures_used(api, [0,1,3,4,5,6,50]);
+                    })
+                    .run()
+            });
+
+            it("to state_retry_parish_search", function() {
+                return tester
+                    .setup.user.addr('0720000111')
+                    .inputs(
+                        {session_event: 'new'}  // dial in
+                        , "1"  // state_language - English
+                        , "2"  // state_choose_number - change number to manage
+                        , "0720000333"  // state_manage_msisdn - unregistered user
+                        , "3"  // state_last_period_month - may
+                        , "22"  // state_last_period_day - 22
+                        , "2"  // state_cellphone_or_search - search
+                        , "foo" // state_parish_search - search for "foo", no results
+                        , "1" // state_no_parish_results - try again
+                    )
+                    .check.interaction({
+                        state: 'state_retry_parish_search',
+                        reply: [
+                            "Please re-enter your parish name carefully and make sure you use the correct spelling."
+                        ].join('\n')
+                    })
+                    .check(function(api) {
+                        go.utils.check_fixtures_used(api, [0,1,3,4,5,6,50]);
+                    })
+                    .run()
+            });
+
+            it("complete flow - vht cellphone", function() {
                 return tester
                     .setup.user.addr('0720000111')
                     .inputs(
@@ -427,6 +536,37 @@ describe("familyconnect health worker app", function() {
                     })
                     .check(function(api) {
                         go.utils.check_fixtures_used(api, [0,1,6,8,16,17,18,19,20,21,48]);
+                    })
+                    .run();
+            });
+
+            it("complete flow - location search", function() {
+                return tester
+                    .setup.user.addr('0720000111')
+                    .inputs(
+                        {session_event: 'new'}  // dial in
+                        , "1"  // state_language - English
+                        , "2"  // state_choose_number - change number to manage
+                        , "0720000555"  // state_manage_msisdn - unregistered user
+                        , "3"  // state_last_period_month - feb 15
+                        , "22"  // state_last_period_day - 22
+                        , "2"  // state_cellphone_or_search - search
+                        , "kawa" // state_parish_search - search "kawa", 5 results
+                        , "1" // state_select_parish - select "Kawaaga"
+                    )
+                    .check.user.answer('state_msg_receiver', 'mother_to_be')
+                    .check.user.answer('receiver_id', 'cb245673-aa41-4302-ac47-0000000555')
+                    .check.user.answer('mother_id', 'cb245673-aa41-4302-ac47-0000000555')
+                    .check.user.answer('hoh_id', 'identity-uuid-06')
+                    .check.user.answer('ff_id', undefined)
+                    .check.user.answer('state_select_parish', 'Kawaaga')
+                    .check.user.answer('vht_personnel_code', undefined)
+                    .check.interaction({
+                        state: 'state_end_thank_you',
+                        reply: "Thank you. Your FamilyConnect ID is 5555555555. You will receive an SMS with it shortly."
+                    })
+                    .check(function(api) {
+                        go.utils.check_fixtures_used(api, [0,1,6,8,16,17,18,20,21,49,51]);
                     })
                     .run();
             });

--- a/test/ussd_public.test.js
+++ b/test/ussd_public.test.js
@@ -495,8 +495,8 @@ describe("familyconnect health worker app", function() {
                         , "3"  // state_last_period_month - may
                         , "22"  // state_last_period_day - 22
                         , "2"  // state_cellphone_or_search - search
-                        , "foo" // state_parish_search - search for "foo", no results
-                        , "1" // state_no_parish_results - try again
+                        , "kawa" // state_parish_search - search for "foo", 5 results
+                        , "6" // state_no_parish_results - try again
                     )
                     .check.interaction({
                         state: 'state_retry_parish_search',
@@ -504,8 +504,9 @@ describe("familyconnect health worker app", function() {
                             "Please re-enter your parish name carefully and make sure you use the correct spelling."
                         ].join('\n')
                     })
+                    .check.user.answer('parish', undefined)
                     .check(function(api) {
-                        go.utils.check_fixtures_used(api, [0,1,3,4,5,6,50]);
+                        go.utils.check_fixtures_used(api, [0,1,3,4,5,6,49]);
                     })
                     .run()
             });
@@ -559,7 +560,7 @@ describe("familyconnect health worker app", function() {
                     .check.user.answer('mother_id', 'cb245673-aa41-4302-ac47-0000000555')
                     .check.user.answer('hoh_id', 'identity-uuid-06')
                     .check.user.answer('ff_id', undefined)
-                    .check.user.answer('state_select_parish', 'Kawaaga')
+                    .check.user.answer('parish', 'Kawaaga')
                     .check.user.answer('vht_personnel_code', undefined)
                     .check.interaction({
                         state: 'state_end_thank_you',


### PR DESCRIPTION
From the results of the UET, we want to have a location search for users who do not know the cellphone number of their local VHT. The search endpoint has been implemented on the django side in https://github.com/praekelt/familyconnect-registration/pull/22 , this PR addresses using the search endpoint in the jssandbox application.
