### PR TITLE
Change from vht personnel code to vht id for registrations

### DIFF
--- a/go-app-sms.js
+++ b/go-app-sms.js
@@ -648,7 +648,7 @@ go.utils_project = {
                 last_period_date: im.user.answers.last_period_date,
                 msg_receiver: im.user.answers.state_msg_receiver,
                 parish: im.user.answers.parish,
-                vht_personnel_code: im.user.answers.vht_personnel_code,
+                vht_id: im.user.answers.vht_id,
             }
         };
 

--- a/go-app-ussd_health_worker.js
+++ b/go-app-ussd_health_worker.js
@@ -648,7 +648,7 @@ go.utils_project = {
                 last_period_date: im.user.answers.last_period_date,
                 msg_receiver: im.user.answers.state_msg_receiver,
                 parish: im.user.answers.parish,
-                vht_personnel_code: im.user.answers.vht_personnel_code,
+                vht_id: im.user.answers.vht_id,
             }
         };
 

--- a/go-app-ussd_public.js
+++ b/go-app-ussd_public.js
@@ -648,7 +648,7 @@ go.utils_project = {
                 last_period_date: im.user.answers.last_period_date,
                 msg_receiver: im.user.answers.state_msg_receiver,
                 parish: im.user.answers.parish,
-                vht_personnel_code: im.user.answers.vht_personnel_code,
+                vht_id: im.user.answers.vht_id,
             }
         };
 
@@ -1780,7 +1780,7 @@ go.app = function() {
                         ]
                     });
                 } else {
-                    self.im.user.set_answer('vht_personnel_code', identity.details.personnel_code);
+                    self.im.user.set_answer('vht_id', identity.id);
                     self.im.user.set_answer('parish', identity.details.parish);
                     return self.states.create('state_finish_registration');
                 }

--- a/src/ussd_public.js
+++ b/src/ussd_public.js
@@ -751,7 +751,7 @@ go.app = function() {
                         ]
                     });
                 } else {
-                    self.im.user.set_answer('vht_personnel_code', identity.details.personnel_code);
+                    self.im.user.set_answer('vht_id', identity.id);
                     self.im.user.set_answer('parish', identity.details.parish);
                     return self.states.create('state_finish_registration');
                 }

--- a/src/utils_project.js
+++ b/src/utils_project.js
@@ -89,7 +89,7 @@ go.utils_project = {
                 last_period_date: im.user.answers.last_period_date,
                 msg_receiver: im.user.answers.state_msg_receiver,
                 parish: im.user.answers.parish,
-                vht_personnel_code: im.user.answers.vht_personnel_code,
+                vht_id: im.user.answers.vht_id,
             }
         };
 

--- a/test/fixtures_public.js
+++ b/test/fixtures_public.js
@@ -643,7 +643,7 @@ return [
                     "last_period_date": "20150222",
                     "msg_receiver": "mother_to_be",
                     "parish": "Kawaaga",
-                    "vht_personnel_code": "888"
+                    "vht_id": "3f7c8851-5204-43f7-af7f-000000000999"
                 }
             }
         },

--- a/test/ussd_public.test.js
+++ b/test/ussd_public.test.js
@@ -530,7 +530,7 @@ describe("familyconnect health worker app", function() {
                     .check.user.answer('hoh_id', 'identity-uuid-06')
                     .check.user.answer('ff_id', undefined)
                     .check.user.answer('parish', 'Kawaaga')
-                    .check.user.answer('vht_personnel_code', '888')
+                    .check.user.answer('vht_id', '3f7c8851-5204-43f7-af7f-000000000999')
                     .check.interaction({
                         state: 'state_end_thank_you',
                         reply: "Thank you. Your FamilyConnect ID is 5555555555. You will receive an SMS with it shortly."


### PR DESCRIPTION
We probably shouldn't be sending and storing the VHT's personnel code for the registration, since that's kind of their password for their access to the system. Also, with the way the identity store is set up, it's easier to find an identity if you have their ID rather than their personnel code.
