### PR TITLE
Allow identities with optouts to re-register

### DIFF
--- a/go-app-sms.js
+++ b/go-app-sms.js
@@ -684,6 +684,9 @@ go.utils_project = {
         details.preferred_language = im.user.answers.state_msg_language;
         details.preferred_msg_type = 'text';  // omit?
         details.hiv_interest = im.user.answers.state_hiv_messages;
+        if (details.addresses.msisdn[im.user.answers.contact_msisdn].optedout) {
+            delete details.addresses.msisdn[im.user.answers.contact_msisdn].optedout;
+        }
 
         return details;
     },

--- a/go-app-ussd_health_worker.js
+++ b/go-app-ussd_health_worker.js
@@ -684,6 +684,9 @@ go.utils_project = {
         details.preferred_language = im.user.answers.state_msg_language;
         details.preferred_msg_type = 'text';  // omit?
         details.hiv_interest = im.user.answers.state_hiv_messages;
+        if (details.addresses.msisdn[im.user.answers.contact_msisdn].optedout) {
+            delete details.addresses.msisdn[im.user.answers.contact_msisdn].optedout;
+        }
 
         return details;
     },

--- a/go-app-ussd_public.js
+++ b/go-app-ussd_public.js
@@ -1323,6 +1323,9 @@ go.app = function() {
                     if (contact.details.addresses.msisdn[msisdn].optedout) {
                         self.im.user.set_answer('contact_id', contact.id);
                         self.im.user.set_answer('contact_msisdn', msisdn);
+                        self.im.user.set_answer('receiver_id', contact.id);
+                        self.im.user.set_answer('hoh_id', contact.details.hoh_id);
+                        self.im.user.set_answer('state_msg_receiver', 'mother_to_be');
                         return self.states.create('state_last_period_month');
                     }
                     if (contact.details.role) {

--- a/go-app-ussd_public.js
+++ b/go-app-ussd_public.js
@@ -684,6 +684,9 @@ go.utils_project = {
         details.preferred_language = im.user.answers.state_msg_language;
         details.preferred_msg_type = 'text';  // omit?
         details.hiv_interest = im.user.answers.state_hiv_messages;
+        if (details.addresses.msisdn[im.user.answers.contact_msisdn].optedout) {
+            delete details.addresses.msisdn[im.user.answers.contact_msisdn].optedout;
+        }
 
         return details;
     },
@@ -1340,6 +1343,7 @@ go.app = function() {
                         return self.states.create('state_change_menu');
                     } else {
                         self.im.user.set_answer('contact_id', contact.id);
+                        self.im.user.set_answer('contact_msisdn', msisdn);
                         return self.states.create('state_save_identities');
                     }
                 });

--- a/go-app-ussd_public.js
+++ b/go-app-ussd_public.js
@@ -1318,11 +1318,17 @@ go.app = function() {
             return go.utils
                 .get_or_create_identity({'msisdn': opts.msisdn}, self.im, null)
                 .then(function(contact) {
+                    msisdn = go.utils
+                        .normalize_msisdn(opts.msisdn, self.im.config.country_code);
+                    if (contact.details.addresses.msisdn[msisdn].optedout) {
+                        self.im.user.set_answer('contact_id', contact.id);
+                        self.im.user.set_answer('contact_msisdn', msisdn);
+                        return self.states.create('state_last_period_month');
+                    }
                     if (contact.details.role) {
                         self.im.user.set_answer('role', contact.details.role);
                         self.im.user.set_answer('contact_id', contact.id);
-                        self.im.user.set_answer('contact_msisdn', go.utils
-                            .normalize_msisdn(opts.msisdn, self.im.config.country_code));
+                        self.im.user.set_answer('contact_msisdn', msisdn);
                         if (contact.details.role === 'mother') {
                             self.im.user.set_answer('mother_id', contact.id);
                         } else {

--- a/src/ussd_public.js
+++ b/src/ussd_public.js
@@ -294,6 +294,9 @@ go.app = function() {
                     if (contact.details.addresses.msisdn[msisdn].optedout) {
                         self.im.user.set_answer('contact_id', contact.id);
                         self.im.user.set_answer('contact_msisdn', msisdn);
+                        self.im.user.set_answer('receiver_id', contact.id);
+                        self.im.user.set_answer('hoh_id', contact.details.hoh_id);
+                        self.im.user.set_answer('state_msg_receiver', 'mother_to_be');
                         return self.states.create('state_last_period_month');
                     }
                     if (contact.details.role) {

--- a/src/ussd_public.js
+++ b/src/ussd_public.js
@@ -311,6 +311,7 @@ go.app = function() {
                         return self.states.create('state_change_menu');
                     } else {
                         self.im.user.set_answer('contact_id', contact.id);
+                        self.im.user.set_answer('contact_msisdn', msisdn);
                         return self.states.create('state_save_identities');
                     }
                 });

--- a/src/ussd_public.js
+++ b/src/ussd_public.js
@@ -289,11 +289,17 @@ go.app = function() {
             return go.utils
                 .get_or_create_identity({'msisdn': opts.msisdn}, self.im, null)
                 .then(function(contact) {
+                    msisdn = go.utils
+                        .normalize_msisdn(opts.msisdn, self.im.config.country_code);
+                    if (contact.details.addresses.msisdn[msisdn].optedout) {
+                        self.im.user.set_answer('contact_id', contact.id);
+                        self.im.user.set_answer('contact_msisdn', msisdn);
+                        return self.states.create('state_last_period_month');
+                    }
                     if (contact.details.role) {
                         self.im.user.set_answer('role', contact.details.role);
                         self.im.user.set_answer('contact_id', contact.id);
-                        self.im.user.set_answer('contact_msisdn', go.utils
-                            .normalize_msisdn(opts.msisdn, self.im.config.country_code));
+                        self.im.user.set_answer('contact_msisdn', msisdn);
                         if (contact.details.role === 'mother') {
                             self.im.user.set_answer('mother_id', contact.id);
                         } else {

--- a/src/utils_project.js
+++ b/src/utils_project.js
@@ -125,6 +125,9 @@ go.utils_project = {
         details.preferred_language = im.user.answers.state_msg_language;
         details.preferred_msg_type = 'text';  // omit?
         details.hiv_interest = im.user.answers.state_hiv_messages;
+        if (details.addresses.msisdn[im.user.answers.contact_msisdn].optedout) {
+            delete details.addresses.msisdn[im.user.answers.contact_msisdn].optedout;
+        }
 
         return details;
     },

--- a/test/fixtures_public.js
+++ b/test/fixtures_public.js
@@ -1815,9 +1815,7 @@ return [
                     "default_addr_type": "msisdn",
                     "addresses": {
                         "msisdn": {
-                            "+256720000888": {
-                              "optedout": true
-                            }
+                            "+256720000888": {}
                         }
                     },
                     "role": "mother",

--- a/test/fixtures_public.js
+++ b/test/fixtures_public.js
@@ -1689,8 +1689,11 @@ return [
                             }
                         },
                         "role": "mother",
-                        "preferred_msg_type": "sms",
+                        "preferred_msg_type": "text",
+                        "msg_receiver": "mother_to_be",
+                        "hoh_id": "identity-uuid-06",
                         "preferred_language": "eng_UG",
+                        "health_id": 8888888888
                     },
                     "created_at": "2015-07-10T06:13:29.693272Z",
                     "updated_at": "2015-07-10T06:13:29.693298Z"

--- a/test/fixtures_public.js
+++ b/test/fixtures_public.js
@@ -6,6 +6,7 @@
 // 0720000555: unregistered user - number entered manually - mother_to_be registration
 // 0720000666: registered user - has baby(postbirth) subscription
 // 0720000777: registered user - servicerating_unanswered flag set to true
+// 0720000888: registered user - previously optedout
 // 0720000999: registered VHT with personnel code and parish
 
 module.exports = function() {
@@ -1651,6 +1652,77 @@ return [
         'response': {
             "code": 201,
             "data": {}
+        }
+    },
+    
+    // 52: get identity 0720000888 by msisdn
+    {
+        'repeatable': true,
+        'request': {
+            'method': 'GET',
+            'params': {
+                'details__addresses__msisdn': '+256720000888'
+            },
+            'headers': {
+                'Authorization': ['Token test_key'],
+                'Content-Type': ['application/json']
+            },
+            'url': 'http://localhost:8001/api/v1/identities/search/',
+        },
+        'response': {
+            "code": 200,
+            "data": {
+                "count": 1,
+                "next": null,
+                "previous": null,
+                "results": [{
+                    "url": "http://localhost:8001/api/v1/identities/3f7c8851-5204-43f7-af7f-000000000888/",
+                    "id": "3f7c8851-5204-43f7-af7f-000000000888",
+                    "version": 1,
+                    "details": {
+                        "default_addr_type": "msisdn",
+                        "addresses": {
+                            "msisdn": {
+                                "+256720000888": {
+                                  "optedout": true
+                                }
+                            }
+                        },
+                        "role": "mother",
+                        "preferred_msg_type": "sms",
+                        "preferred_language": "eng_UG",
+                    },
+                    "created_at": "2015-07-10T06:13:29.693272Z",
+                    "updated_at": "2015-07-10T06:13:29.693298Z"
+                }]
+            }
+        }
+    },
+
+    // 53: get identity 3f7c8851-5204-43f7-af7f-000000000888 service rating status
+    {
+        'repeatable': true,
+        'request': {
+            'method': 'GET',
+            'params': {
+                "identity": "3f7c8851-5204-43f7-af7f-000000000888",
+                "completed": 'False',
+                "expired": 'False'
+            },
+            'headers': {
+                'Authorization': ['Token test_key'],
+                'Content-Type': ['application/json']
+            },
+            'url': 'http://localhost:8006/api/v1/invite/',
+        },
+        'response': {
+            "code": 200,
+            "data": {
+                "count": 0,
+                "next": null,
+                "previous": null,
+                "results": []
+            }
         }
     },
 ];

--- a/test/fixtures_public.js
+++ b/test/fixtures_public.js
@@ -1728,5 +1728,137 @@ return [
             }
         }
     },
+
+    // 54: get identity 3f7c8851-5204-43f7-af7f-000000000888
+    {
+        'repeatable': true,  // second time gets the health_id
+        'request': {
+            'method': 'GET',
+            'params': {},
+            'headers': {
+                'Authorization': ['Token test_key'],
+                'Content-Type': ['application/json']
+            },
+            'url': "http://localhost:8001/api/v1/identities/3f7c8851-5204-43f7-af7f-000000000888/",
+        },
+        'response': {
+            "code": 200,
+            "data": {
+                "url": "http://localhost:8001/api/v1/identities/3f7c8851-5204-43f7-af7f-000000000888/",
+                "id": "3f7c8851-5204-43f7-af7f-000000000888",
+                "version": 1,
+                "details": {
+                    "default_addr_type": "msisdn",
+                    "addresses": {
+                        "msisdn": {
+                            "+256720000888": {
+                              "optedout": true
+                            }
+                        }
+                    },
+                    "role": "mother",
+                    "preferred_msg_type": "text",
+                    "msg_receiver": "mother_to_be",
+                    "hoh_id": "identity-uuid-06",
+                    "preferred_language": "eng_UG",
+                    "health_id": 8888888888
+                },
+                "created_at": "2015-07-10T06:13:29.693272Z",
+                "updated_at": "2015-07-10T06:13:29.693298Z"
+            }
+        }
+    },
+
+    // 55: create registration 4
+    {
+        'request': {
+            'method': 'POST',
+            'headers': {
+                'Authorization': ['Token test_key'],
+                'Content-Type': ['application/json']
+            },
+            'url': 'http://localhost:8002/api/v1/registration/',
+            'data':  {
+                "stage": "prebirth",
+                "mother_id": "3f7c8851-5204-43f7-af7f-000000000888",
+                "data": {
+                    "hoh_id": "identity-uuid-06",
+                    "receiver_id": "3f7c8851-5204-43f7-af7f-000000000888",
+                    "operator_id": null,
+                    "language": "eng_UG",
+                    "msg_type": "text",
+                    "last_period_date": "20150222",
+                    "msg_receiver": "mother_to_be",
+                    "parish": "Kawaaga",
+                }
+            }
+        },
+        'response': {
+            "code": 201,
+            "data": {}
+        }
+    },
+
+    // 56: patch identity 3f7c8851-5204-43f7-af7f-000000000888
+    {
+        'request': {
+            'method': 'PATCH',
+            'headers': {
+                'Authorization': ['Token test_key'],
+                'Content-Type': ['application/json']
+            },
+            'url': 'http://localhost:8001/api/v1/identities/3f7c8851-5204-43f7-af7f-000000000888/',
+            'data':  {
+                "id": "3f7c8851-5204-43f7-af7f-000000000888",
+                "version": 1,
+                "details": {
+                    "default_addr_type": "msisdn",
+                    "addresses": {
+                        "msisdn": {
+                            "+256720000888": {
+                              "optedout": true
+                            }
+                        }
+                    },
+                    "role": "mother",
+                    "preferred_msg_type": "text",
+                    "msg_receiver": "mother_to_be",
+                    "hoh_id": "identity-uuid-06",
+                    "health_id": 8888888888
+                }
+            }
+        },
+        'response': {
+            "code": 200,
+            "data": {}
+        }
+    },
+
+    // 57: patch identity 06
+    {
+        'request': {
+            'method': 'PATCH',
+            'headers': {
+                'Authorization': ['Token test_key'],
+                'Content-Type': ['application/json']
+            },
+            'url': 'http://localhost:8001/api/v1/identities/identity-uuid-06/',
+            'data':  {
+                "id": "identity-uuid-06",
+                "version": 1,
+                "details": {
+                    "default_addr_type": "msisdn",
+                    "addresses": {},
+                    "role": "head_of_household",
+                    "mother_id": "3f7c8851-5204-43f7-af7f-000000000888",
+                    "preferred_msg_type": "text"
+                }
+            }
+        },
+        'response': {
+            "code": 200,
+            "data": {}
+        }
+    },
 ];
 };

--- a/test/ussd_public.test.js
+++ b/test/ussd_public.test.js
@@ -593,6 +593,34 @@ describe("familyconnect public app", function() {
                     })
                     .run();
             });
+
+            it("complete flow - optedout number", function() {
+                return tester
+                    .setup.user.addr('0720000888')
+                    .inputs(
+                        {session_event: 'new'}  // dial in
+                        , "3"  // state_last_period_month - feb 15
+                        , "22"  // state_last_period_day - 22
+                        , "2"  // state_cellphone_or_search - search
+                        , "kawa" // state_parish_search - search "kawa", 5 results
+                        , "1" // state_select_parish - select "Kawaaga"
+                    )
+                    .check.user.answer('state_msg_receiver', 'mother_to_be')
+                    .check.user.answer('receiver_id', '3f7c8851-5204-43f7-af7f-000000000888')
+                    .check.user.answer('mother_id', '3f7c8851-5204-43f7-af7f-000000000888')
+                    .check.user.answer('hoh_id', 'identity-uuid-06')
+                    .check.user.answer('ff_id', undefined)
+                    .check.user.answer('parish', 'Kawaaga')
+                    .check.user.answer('vht_personnel_code', undefined)
+                    .check.interaction({
+                        state: 'state_end_thank_you',
+                        reply: "Thank you. Your FamilyConnect ID is 8888888888. You will receive an SMS with it shortly."
+                    })
+                    .check(function(api) {
+                        go.utils.check_fixtures_used(api, [8,49,52,53,54,55,56,57]);
+                    })
+                    .run();
+            });
         });
 
         describe("Change testing", function() {

--- a/test/ussd_public.test.js
+++ b/test/ussd_public.test.js
@@ -2,7 +2,7 @@ var vumigo = require('vumigo_v02');
 var fixtures = require('./fixtures_public');
 var AppTester = vumigo.AppTester;
 
-describe("familyconnect health worker app", function() {
+describe("familyconnect public app", function() {
     describe("for ussd use", function() {
         var app;
         var tester;
@@ -268,6 +268,32 @@ describe("familyconnect health worker app", function() {
                     })
                     .check(function(api) {
                         go.utils.check_fixtures_used(api, [2,45]);
+                    })
+                    .run();
+            });
+            it("to state_last_period_month (recognised, optedout user)", function() {
+                return tester
+                    .setup.user.addr('0720000888')
+                    .inputs(
+                        {session_event: 'new'}  // dial in
+                    )
+                    .check.interaction({
+                        state: 'state_last_period_month',
+                        reply: [
+                            "What month did you start your last period?",
+                            "1. Apr 15",
+                            "2. Mar 15",
+                            "3. Feb 15",
+                            "4. Jan 15",
+                            "5. Dec 14",
+                            "6. Nov 14",
+                            "7. Oct 14",
+                            "8. Sep 14",
+                            "9. Aug 14"
+                        ].join('\n')
+                    })
+                    .check(function(api) {
+                        go.utils.check_fixtures_used(api, [52,53]);
                     })
                     .run();
             });

--- a/test/ussd_public.test.js
+++ b/test/ussd_public.test.js
@@ -281,15 +281,13 @@ describe("familyconnect public app", function() {
                         state: 'state_last_period_month',
                         reply: [
                             "What month did you start your last period?",
-                            "1. Apr 15",
-                            "2. Mar 15",
-                            "3. Feb 15",
-                            "4. Jan 15",
-                            "5. Dec 14",
-                            "6. Nov 14",
-                            "7. Oct 14",
-                            "8. Sep 14",
-                            "9. Aug 14"
+                            "1. April 2015",
+                            "2. March 2015",
+                            "3. February 2015",
+                            "4. January 2015",
+                            "5. December 2014",
+                            "6. November 2014",
+                            "7. More",
                         ].join('\n')
                     })
                     .check(function(api) {


### PR DESCRIPTION
Currently mothers who have opted out of communications will not be able to re-register on the public line because they will be directed to the change menu state.
This change instead retrieves the information we already have for them and sends them straight to the period month state.